### PR TITLE
Add Guardian breakpoints to Storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,5 +2,5 @@ const path = require("path");
 
 module.exports = {
   stories: ["../src/**/*.stories.tsx"],
-  addons: ["@storybook/addon-knobs"],
+  addons: ["@storybook/addon-knobs", "@storybook/addon-viewport"],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,58 @@
+import { addParameters } from "@storybook/react";
+import { breakpoints } from "@guardian/src-foundations";
+
+const viewportMeta = {
+  mobile: {
+    name: "Mobile",
+    type: "mobile",
+  },
+  mobileMedium: {
+    name: "Mobile Medium",
+    type: "mobile",
+  },
+  mobileLandscape: {
+    name: "Mobile Landscape",
+    type: "mobile",
+  },
+  phablet: {
+    name: "Phablet",
+    type: "mobile",
+  },
+  tablet: {
+    name: "Tablet",
+    type: "tablet",
+  },
+  desktop: {
+    name: "Desktop",
+    type: "desktop",
+  },
+  leftCol: {
+    name: "Left Col",
+    type: "desktop",
+  },
+  wide: {
+    name: "Wide",
+    type: "desktop",
+  },
+};
+const viewportEntries = Object.entries(breakpoints).map(([name, width]) => {
+  return [
+    name,
+    {
+      name: viewportMeta[name].name,
+      styles: {
+        width: `${width}px`,
+        height: "100%",
+      },
+      type: viewportMeta[name].type,
+    },
+  ];
+});
+const viewports = Object.fromEntries(viewportEntries);
+
+addParameters({
+  viewport: {
+    viewports,
+    defaultViewport: "responsive",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-replace": "^2.3.3",
     "@storybook/addon-knobs": "^6.0.21",
+    "@storybook/addon-viewport": "^6.0.21",
     "@storybook/preset-typescript": "^3.0.0",
     "@storybook/react": "^5.3.19",
     "@types/react": "^16.9.44",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,6 +1755,23 @@
     react-select "^3.0.8"
     regenerator-runtime "^0.13.3"
 
+"@storybook/addon-viewport@^6.0.21":
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-6.0.21.tgz#d765921244f9e000209833c8cc05064e767894c2"
+  integrity sha512-FFUkhpZy7npRTaqX9SwMz5Yzo0/ivuApwr47xqblDEEyq7edWqo7YKsPnpAGeM9MlRpQNf6aU9huwDqKeRfKuQ==
+  dependencies:
+    "@storybook/addons" "6.0.21"
+    "@storybook/api" "6.0.21"
+    "@storybook/client-logger" "6.0.21"
+    "@storybook/components" "6.0.21"
+    "@storybook/core-events" "6.0.21"
+    "@storybook/theming" "6.0.21"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    prop-types "^15.7.2"
+    regenerator-runtime "^0.13.3"
+
 "@storybook/addons@5.3.19":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.19.tgz#3a7010697afd6df9a41b8c8a7351d9a06ff490a4"


### PR DESCRIPTION
## What does this change?

Adds easy switching between source viewport widths to Storybook (viewport config taken from the support-dotcom-components project).