### PR TITLE
Buttons IDs and property name consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/braze-components",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "React components to render messages from Braze",
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",

--- a/src/DigitalSubscriberAppBanner.stories.tsx
+++ b/src/DigitalSubscriberAppBanner.stories.tsx
@@ -16,8 +16,8 @@ export const defaultStory = (): ReactElement => {
         onButtonClick={(buttonId) => {
           console.log(`Button ${buttonId} clicked`);
         }}
-        header={text("Header", "A note to our digital subscribers")}
-        body={text("Body", "Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.")}
+        header={text("header", "A note to our digital subscribers")}
+        body={text("body", "Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.")}
       />
     </StorybookWrapper>
   );

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -11,7 +11,7 @@ import { PlayStore } from "./assets/play-store"
 const imgHeight = "300";
 
 export type Props = {
-  onButtonClick: (buttonType: string) => void;
+  onButtonClick: (buttonIndex: number) => void;
   header?: string;
   body?: string;
 };
@@ -292,7 +292,7 @@ export const DigitalSubscriberAppBanner: React.FC<Props> = ({
 }: Props) => {
     const [showBanner, setShowBanner] = useState(true);
 
-    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>, buttonId: string): void => {
+    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>, buttonId: number): void => {
         evt.preventDefault();
         onButtonClick(buttonId);
         setShowBanner(false);
@@ -323,8 +323,8 @@ export const DigitalSubscriberAppBanner: React.FC<Props> = ({
                             <PlayStore />
                         </span>
                     </p>
-                    <Button onClick={e => onCloseClick(e, '0')} css={primaryButton}>Ok, got it</Button>
-                    <Button onClick={e => onCloseClick(e, '1')} css={secondaryButton} priority="subdued">I'm not interested</Button>
+                    <Button onClick={e => onCloseClick(e, 0)} css={primaryButton}>Ok, got it</Button>
+                    <Button onClick={e => onCloseClick(e, 1)} css={secondaryButton} priority="subdued">I'm not interested</Button>
                 </div>
                 <div css={bottomRightComponent}>
                     <div css={packShot}>
@@ -336,7 +336,7 @@ export const DigitalSubscriberAppBanner: React.FC<Props> = ({
                     <div css={iconPanel}>
                         <button
                             aria-label="Close"
-                            onClick={e => onCloseClick(e, '1')}
+                            onClick={e => onCloseClick(e, 1)}
                             css={closeButton}
                         >
                             <SvgCross />


### PR DESCRIPTION
## What does this change?
I've changed the integers in strings used as button IDs to be pure numbers - once called in Frontend or DCR, the InAppMessageButtonClick constructor expects a number, so providing a number-typed value here saves us work in the repositories where the component is used.

I've also updated the case of the property names displayed in Storybook (i.e. "header", "body") to be lower case, in order to exactly match their names in the Braze interface.

## How to test
The component can be tested in Storybook using `yarn storybook`.
