### PR TITLE
Accessibility improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/braze-components",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "React components to render messages from Braze",
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -344,7 +344,7 @@ export const DigitalSubscriberAppBanner: React.FC<Props> = ({
                             aria-label="Close"
                             onClick={e => onCloseClick(e, 1)}
                             css={closeButton}
-                            tabIndex={1}
+                            tabIndex={0}
                         >
                             <SvgCross />
                         </button>

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -5,8 +5,9 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography/cjs';
 import { Button } from "@guardian/src-button";
 import { SvgCross, SvgInfo } from '@guardian/src-icons';
-import { AppStore } from "./assets/app-store"
-import { PlayStore } from "./assets/play-store"
+import { AppStore } from "./assets/app-store";
+import { PlayStore } from "./assets/play-store";
+import { focusHalo } from "@guardian/src-foundations/accessibility";
 
 const imgHeight = "300";
 
@@ -232,6 +233,11 @@ export const closeButton = css`
         cursor: pointer;
         background-color: rgba(237, 237, 237, 0.5);
     }
+
+    transition: box-shadow 0.3s;
+    :focus {
+        ${focusHalo};
+    }  
 `;
 
 export const smallInfoIcon = css`

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -344,6 +344,7 @@ export const DigitalSubscriberAppBanner: React.FC<Props> = ({
                             aria-label="Close"
                             onClick={e => onCloseClick(e, 1)}
                             css={closeButton}
+                            tabIndex={1}
                         >
                             <SvgCross />
                         </button>


### PR DESCRIPTION
## What does this change?
The `closeButton` is now keyboard focusable, showing the focusHalo when navigated to using the tab key. For now, the tabindex has been set to 0, but could be increased based on feedback from the E&P/Accessibility group.

There is an open question of how the banner should be navigated to - screen-reader users may find the banner unobtrusive as it is (because it's sequentially after the main page content), while users navigating by keyboard may want to close it without tabbing through the rest of the page.

## How to test
View in storybook by running `yarn storybook`.

![image](https://user-images.githubusercontent.com/34686302/93100633-4bcb3e80-f6a1-11ea-9393-b10ac3bcdd56.png)
