### PR TITLE
Get eslint & prettier working consistently

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+; This file is for unifying the coding style for different editors and IDEs
+; See editorconfig.org
+
+; top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[package.json]
+indent_size = 2
+
+[makefile]
+indent_style = tab
+
+[*.yml]
+indent_size = 2

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,37 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    extends: [
+        'plugin:@typescript-eslint/recommended',
+        'plugin:react/recommended',
+        'plugin:prettier/recommended',
+    ],
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: {
+            jsx: true, // Allows for the parsing of JSX
+        },
+    },
+    rules: {
+        // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
+        // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+        curly: 2,
+        '@typescript-eslint/no-inferrable-types': [
+            'error',
+            {
+                ignoreParameters: true,
+            },
+        ],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                args: 'after-used',
+            },
+        ],
+    },
+    settings: {
+        react: {
+            version: 'detect',
+        },
+    },
+};

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    semi: true,
+    trailingComma: 'all',
+    singleQuote: true,
+    printWidth: 100,
+    tabWidth: 4,
+};

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export * from "./src/DigitalSubscriberAppBanner";
+export * from './src/DigitalSubscriberAppBanner';

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react": "^7.20.6",
     "install-peers-cli": "^2.2.0",
     "prettier": "^2.0.5",
     "rollup": "^2.23.0",

--- a/src/DigitalSubscriberAppBanner.stories.tsx
+++ b/src/DigitalSubscriberAppBanner.stories.tsx
@@ -1,26 +1,29 @@
-import React, { ReactElement } from "react";
-import { withKnobs, text } from "@storybook/addon-knobs";
-import { DigitalSubscriberAppBanner } from "./DigitalSubscriberAppBanner";
-import { StorybookWrapper } from "./utils/StorybookWrapper";
+import React, { ReactElement } from 'react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import { DigitalSubscriberAppBanner } from './DigitalSubscriberAppBanner';
+import { StorybookWrapper } from './utils/StorybookWrapper';
 
 export default {
-  component: DigitalSubscriberAppBanner,
-  title: "Components/DigitalSubscriberAppBanner",
-  decorators: [withKnobs],
+    component: DigitalSubscriberAppBanner,
+    title: 'Components/DigitalSubscriberAppBanner',
+    decorators: [withKnobs],
 };
 
 export const defaultStory = (): ReactElement => {
-  return (
-    <StorybookWrapper>
-      <DigitalSubscriberAppBanner
-        onButtonClick={(buttonId) => {
-          console.log(`Button ${buttonId} clicked`);
-        }}
-        header={text("header", "A note to our digital subscribers")}
-        body={text("body", "Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.")}
-      />
-    </StorybookWrapper>
-  );
+    return (
+        <StorybookWrapper>
+            <DigitalSubscriberAppBanner
+                onButtonClick={(buttonId) => {
+                    console.log(`Button ${buttonId} clicked`);
+                }}
+                header={text('header', 'A note to our digital subscribers')}
+                body={text(
+                    'body',
+                    'Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.',
+                )}
+            />
+        </StorybookWrapper>
+    );
 };
 
-defaultStory.story = { name: "Digital Subscriber App Banner" };
+defaultStory.story = { name: 'Digital Subscriber App Banner' };

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -1,44 +1,44 @@
 import React, { useState } from 'react';
-import { css } from "@emotion/core";
-import { ThemeProvider } from 'emotion-theming'
-import { palette, space } from "@guardian/src-foundations";
+import { css } from '@emotion/core';
+import { ThemeProvider } from 'emotion-theming';
+import { palette, space } from '@guardian/src-foundations';
 import { from, until } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography/cjs';
-import { Button, buttonReaderRevenueBrandAlt } from "@guardian/src-button";
+import { Button, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { SvgCross, SvgInfo } from '@guardian/src-icons';
-import { AppStore } from "./assets/app-store";
-import { PlayStore } from "./assets/play-store";
+import { AppStore } from './assets/app-store';
+import { PlayStore } from './assets/play-store';
 
-const imgHeight = "280";
-const bannerColor = "#ebe8e8";
-const infoColor = "#c4c4c4";
-const bodyColor = "#666";
+const imgHeight = '280';
+const bannerColor = '#ebe8e8';
+const infoColor = '#c4c4c4';
+const bodyColor = '#666';
 
 export type Props = {
-  onButtonClick: (buttonIndex: number) => void;
-  header?: string;
-  body?: string;
+    onButtonClick: (buttonIndex: number) => void;
+    header?: string;
+    body?: string;
 };
 
 export const wrapper = css`
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  background-color: ${bannerColor};
-  color: ${palette.neutral[20]};
-
-  html {
     box-sizing: border-box;
-  }
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    background-color: ${bannerColor};
+    color: ${palette.neutral[20]};
 
-  *,
-  *:before,
-  *:after {
-    box-sizing: inherit;
-  }
+    html {
+        box-sizing: border-box;
+    }
+
+    *,
+    *:before,
+    *:after {
+        box-sizing: inherit;
+    }
 `;
 
 export const contentContainer = css`
@@ -148,13 +148,13 @@ export const cta = css`
     margin-right: ${space[3]}px;
     display: inline-block;
     color: ${palette.neutral[20]};
-`
+`;
 
 export const smallRightSpacer = css`
     margin-right: ${space[3]}px;
-`
+`;
 
-export const primaryButton = css `
+export const primaryButton = css`
     margin-right: ${space[3]}px;
     background-color: ${palette.neutral[20]};
     color: ${palette.neutral[100]};
@@ -162,11 +162,11 @@ export const primaryButton = css `
     &:hover {
         background-color: #111;
     }
-`
+`;
 
-export const secondaryButton = css `
+export const secondaryButton = css`
     color: ${palette.neutral[20]};
-`
+`;
 
 export const packShot = css`
     max-width: 100%;
@@ -203,7 +203,6 @@ export const iconPanel = css`
     }
 `;
 
-
 export const closeButton = css`
     display: flex;
     align-items: center;
@@ -223,10 +222,16 @@ export const smallInfoIcon = css`
         height: 40px;
         vertical-align: -30%;
         fill: ${infoColor};
-        background: radial-gradient(circle at center, ${palette.background.primary} 0%, ${palette.background.primary} 50%, ${palette.background.primary} 52%, transparent 53%);
+        background: radial-gradient(
+            circle at center,
+            ${palette.background.primary} 0%,
+            ${palette.background.primary} 50%,
+            ${palette.background.primary} 52%,
+            transparent 53%
+        );
     }
 
-    ${until.phablet}{
+    ${until.phablet} {
         display: block;
         margin-left: -4px;
         margin-top: -4px;
@@ -241,16 +246,22 @@ export const infoIcon = css`
     left: -60px;
     top: 10px;
     display: none;
-    
+
     svg {
         width: 60px;
         height: 60px;
         fill: ${infoColor};
-        background: radial-gradient(circle at center, ${palette.background.primary} 0%, ${palette.background.primary} 50%, ${palette.background.primary} 52%, transparent 53%);
+        background: radial-gradient(
+            circle at center,
+            ${palette.background.primary} 0%,
+            ${palette.background.primary} 50%,
+            ${palette.background.primary} 52%,
+            transparent 53%
+        );
         border-radius: 50%;
     }
 
-    @media (min-width: 1430px){
+    @media (min-width: 1430px) {
         display: block;
     }
 `;
@@ -269,20 +280,26 @@ export const storeIcon = css`
 `;
 
 export const DigitalSubscriberAppBanner: React.FC<Props> = ({
-  onButtonClick,
-  header,
-  body
+    onButtonClick,
+    header,
+    body,
 }: Props) => {
     const [showBanner, setShowBanner] = useState(true);
 
-    const onCloseClick = (evt: React.MouseEvent<HTMLButtonElement, MouseEvent>, buttonId: number): void => {
+    const onCloseClick = (
+        evt: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        buttonId: number,
+    ): void => {
         evt.preventDefault();
         onButtonClick(buttonId);
         setShowBanner(false);
     };
-    
-    if (!showBanner || !header || !body ) return null;
-    else return (
+
+    if (!showBanner || !header || !body) {
+        return null;
+    }
+
+    return (
         <div css={wrapper}>
             <div css={contentContainer}>
                 <div css={topLeftComponent}>
@@ -297,17 +314,23 @@ export const DigitalSubscriberAppBanner: React.FC<Props> = ({
                     </div>
                     <p css={paragraph}>
                         {body}
-                        <br/>
-                        <strong css={cta}>
-                            Search for "Guardian live news"
-                        </strong>
+                        <br />
+                        <strong css={cta}>Search for "Guardian live news"</strong>
                         <span css={storeIcon}>
                             <AppStore />
                             <PlayStore />
                         </span>
                     </p>
-                    <Button onClick={e => onCloseClick(e, 0)} css={primaryButton}>Ok, got it</Button>
-                    <Button onClick={e => onCloseClick(e, 1)} css={secondaryButton} priority="subdued">I'm not interested</Button>
+                    <Button onClick={(e) => onCloseClick(e, 0)} css={primaryButton}>
+                        Ok, got it
+                    </Button>
+                    <Button
+                        onClick={(e) => onCloseClick(e, 1)}
+                        css={secondaryButton}
+                        priority="subdued"
+                    >
+                        I'm not interested
+                    </Button>
                 </div>
                 <div css={bottomRightComponent}>
                     <div css={packShot}>
@@ -325,13 +348,15 @@ export const DigitalSubscriberAppBanner: React.FC<Props> = ({
                                 priority="tertiary"
                                 size="small"
                                 aria-label="Close"
-                                onClick={e => onCloseClick(e, 1)}
+                                onClick={(e) => onCloseClick(e, 1)}
                                 tabIndex={0}
-                            > </Button>
+                            >
+                                {' '}
+                            </Button>
                         </ThemeProvider>
                     </div>
                 </div>
             </div>
-        </div> 
+        </div>
     );
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,7 +3259,7 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
-array-includes@^3.0.3:
+array-includes@^3.0.3, array-includes@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
   integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
@@ -3298,7 +3298,7 @@ array.prototype.flat@^1.2.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-array.prototype.flatmap@^1.2.1:
+array.prototype.flatmap@^1.2.1, array.prototype.flatmap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz#1c13f84a178566042dd63de4414440db9222e443"
   integrity sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
@@ -5415,6 +5415,13 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -5824,6 +5831,23 @@ eslint-plugin-prettier@^3.1.4:
   integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-react@^7.20.6:
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz#4d7845311a93c463493ccfa0a19c9c5d0fd69f60"
+  integrity sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flatmap "^1.2.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1"
+    object.entries "^1.1.2"
+    object.fromentries "^2.0.2"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    resolve "^1.17.0"
+    string.prototype.matchall "^4.0.2"
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -8708,6 +8732,14 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsx-ast-utils@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz#1114a4c1209481db06c690c2b4f488cc665f657e"
+  integrity sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==
+  dependencies:
+    array-includes "^3.1.1"
+    object.assign "^4.1.0"
+
 junit-report-builder@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/junit-report-builder/-/junit-report-builder-2.0.0.tgz#aaf9c8c6848cd9bb9dfb6da8e2f411d72ddf47aa"
@@ -10235,7 +10267,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.1.0:
+object.entries@^1.1.0, object.entries@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
   integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
@@ -10244,7 +10276,7 @@ object.entries@^1.1.0:
     es-abstract "^1.17.5"
     has "^1.0.3"
 
-"object.fromentries@^2.0.0 || ^1.0.0":
+"object.fromentries@^2.0.0 || ^1.0.0", object.fromentries@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.2.tgz#4a09c9b9bb3843dd0f89acdb517a794d4f355ac9"
   integrity sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==
@@ -10269,7 +10301,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-object.values@^1.1.0:
+object.values@^1.1.0, object.values@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
   integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
@@ -12862,7 +12894,7 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-"string.prototype.matchall@^4.0.0 || ^3.0.1":
+"string.prototype.matchall@^4.0.0 || ^3.0.1", string.prototype.matchall@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz#48bb510326fb9fdeb6a33ceaa81a6ea04ef7648e"
   integrity sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==


### PR DESCRIPTION
## What does this change?

I noticed that the formatting my editor was applying was different than the recent commits made by Rhys. It turned out that we didn’t have eslint and prettier config for this repo. Added and reformatted the main component and story. Slightly annoying to have to do this because the diff is noisy, but better now than down the line when we're supporting more components.

There should be no user-visible changes from this PR.