### PR TITLE
Publish Package as an ES Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",
   "license": "MIT",
-  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ const configs = [['./index.ts', './dist/index.js']].map(([input, file]) => ({
     input: input,
     output: {
         file: file,
-        format: 'cjs',
+        format: 'module',
         sourcemap: false,
     },
     external: (id) => Object.keys(globals).some((key) => id == key),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,48 +1,48 @@
-import babel from "@rollup/plugin-babel";
-import { DEFAULT_EXTENSIONS } from "@babel/core";
-import filesize from "rollup-plugin-filesize";
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
-import replace from "@rollup/plugin-replace";
-import alias from "@rollup/plugin-alias";
-import { terser } from "rollup-plugin-terser";
-import peerDepsExternal from "rollup-plugin-peer-deps-external";
-import externalGlobals from "rollup-plugin-external-globals";
+import babel from '@rollup/plugin-babel';
+import { DEFAULT_EXTENSIONS } from '@babel/core';
+import filesize from 'rollup-plugin-filesize';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+import alias from '@rollup/plugin-alias';
+import { terser } from 'rollup-plugin-terser';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import externalGlobals from 'rollup-plugin-external-globals';
 
-const extensions = [...DEFAULT_EXTENSIONS, ".ts", ".tsx"];
+const extensions = [...DEFAULT_EXTENSIONS, '.ts', '.tsx'];
 
 const globals = {
-  react: "guardian.automat.preact",
-  "@emotion/core": "guardian.automat.emotionCore",
+    react: 'guardian.automat.preact',
+    '@emotion/core': 'guardian.automat.emotionCore',
 };
 
-const configs = [["./index.ts", "./dist/index.js"]].map(([input, file]) => ({
-  input: input,
-  output: {
-    file: file,
-    format: "cjs",
-    sourcemap: false,
-  },
-  external: (id) => Object.keys(globals).some((key) => id == key),
-  plugins: [
-    peerDepsExternal(),
-    // alias({
-    //   entries: [
-    //     { find: "react", replacement: "preact-x/compat" },
-    //     { find: "react-dom", replacement: "preact-x/compat" },
-    //   ],
-    // }),
-    resolve({ extensions: extensions }),
-    commonjs(),
-    replace({ "process.env.NODE_ENV": '"production"' }),
-    babel({
-      babelHelpers: "bundled",
-      extensions: extensions,
-    }),
-    terser(),
-    filesize(),
-    externalGlobals(globals),
-  ],
+const configs = [['./index.ts', './dist/index.js']].map(([input, file]) => ({
+    input: input,
+    output: {
+        file: file,
+        format: 'cjs',
+        sourcemap: false,
+    },
+    external: (id) => Object.keys(globals).some((key) => id == key),
+    plugins: [
+        peerDepsExternal(),
+        // alias({
+        //   entries: [
+        //     { find: "react", replacement: "preact-x/compat" },
+        //     { find: "react-dom", replacement: "preact-x/compat" },
+        //   ],
+        // }),
+        resolve({ extensions: extensions }),
+        commonjs(),
+        replace({ 'process.env.NODE_ENV': '"production"' }),
+        babel({
+            babelHelpers: 'bundled',
+            extensions: extensions,
+        }),
+        terser(),
+        filesize(),
+        externalGlobals(globals),
+    ],
 }));
 
 export default configs;


### PR DESCRIPTION
## What does this change?

Publish our package as an ES module

This is the [approach we’re settling on in Client Side infra discussions](https://github.com/orgs/guardian/teams/client-side-infra/discussions/11).

Furthermore, without this change the module no longer loads correctly on frontend since guardian/frontend#23011 was merged, which changes the config to transpile all @guardian NPM packages.

## Images

Here's the banner component loading successfully on DCR and frontend (I've forced the component to load, rather than triggering from Braze, which is why the copy is wrong):

<img width="1552" alt="Screenshot 2020-09-23 at 16 09 54" src="https://user-images.githubusercontent.com/379839/94035844-8167da00-fdbb-11ea-8d38-d1c3f554c378.png">

<img width="1552" alt="Screenshot 2020-09-23 at 16 18 36" src="https://user-images.githubusercontent.com/379839/94035859-8af14200-fdbb-11ea-88b2-5e4a80fc88db.png">

