### PR TITLE
Added css fix for IE11 and Edge

### DIFF
--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -70,8 +70,8 @@ export const contentContainer = css`
 export const topLeftComponent = css`
     width: 93%;
     padding: ${space[4]}px;
-    min-height: ${imgHeight};
-    {from.desktop} {
+    min-height: ${imgHeight}px;
+    ${from.desktop} {
         width: 60%;
     }
 `;
@@ -81,7 +81,7 @@ export const bottomRightComponent = css`
     justify-content: center;
     width: 100%;
     max-height: 100%;
-    min-height: ${imgHeight};
+    min-height: ${imgHeight}px;
 
     ${from.desktop} {
         align-self: flex-end;

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -81,7 +81,6 @@ export const bottomRightComponent = css`
     justify-content: center;
     width: 100%;
     max-height: 100%;
-    min-height: ${imgHeight}px;
 
     ${from.desktop} {
         align-self: flex-end;

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -180,9 +180,11 @@ export const packShot = css`
 
     img {
         max-width: 100%;
-        max-height: 100%;
+        width: 100%;
+        height: 100%;
         object-fit: contain;
     }
+
 
     ${until.desktop} {
         display: none;
@@ -276,6 +278,7 @@ export const storeIcon = css`
     svg {
         height: 30px;
         width: auto;
+        max-width: 110px;
         margin-top: ${space[2]}px;
         padding-right: ${space[2]}px;
     }

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -70,8 +70,8 @@ export const contentContainer = css`
 export const topLeftComponent = css`
     width: 93%;
     padding: ${space[4]}px;
-
-    ${from.desktop} {
+    min-height: ${imgHeight};
+    {from.desktop} {
         width: 60%;
     }
 `;
@@ -81,6 +81,7 @@ export const bottomRightComponent = css`
     justify-content: center;
     width: 100%;
     max-height: 100%;
+    min-height: ${imgHeight};
 
     ${from.desktop} {
         align-self: flex-end;

--- a/src/DigitalSubscriberAppBanner.tsx
+++ b/src/DigitalSubscriberAppBanner.tsx
@@ -185,7 +185,6 @@ export const packShot = css`
         object-fit: contain;
     }
 
-
     ${until.desktop} {
         display: none;
     }


### PR DESCRIPTION
## What does this change?
A small fix for IE11 and Edge, keeping the primary image in correct dimensions and keeping the app store icons inline.