### PR TITLE
Publish package as esm and cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",
   "license": "MIT",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+	"module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/braze-components",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "React components to render messages from Braze",
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",
   "license": "MIT",
   "main": "dist/index.js",
-	"module": "dist/index.esm.js",
+  "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import alias from '@rollup/plugin-alias';
 import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import externalGlobals from 'rollup-plugin-external-globals';
+import pkg from './package.json';
 
 const extensions = [...DEFAULT_EXTENSIONS, '.ts', '.tsx'];
 
@@ -18,11 +19,17 @@ const globals = {
 
 const configs = [['./index.ts', './dist/index.js']].map(([input, file]) => ({
     input: input,
-    output: {
-        file: file,
-        format: 'module',
-        sourcemap: false,
-    },
+    output: [
+        {
+            file: pkg.main,
+            format: 'cjs',
+        },
+        {
+            file: pkg.module,
+            format: 'esm',
+            sourcemap: false,
+        },
+    ],
     external: (id) => Object.keys(globals).some((key) => id == key),
     plugins: [
         peerDepsExternal(),


### PR DESCRIPTION
## What does this change?

This switches to publishing the package as esm and cjs. I followed the example of the cmp library. When only publishing as esm I ran into an issue where the linter was failing the find the package on the platforms. This seems to fix the issue.

Note that in order to test this I published the package off of this branch (`0.0.10`).