### PR TITLE
Add Rollup Visualizer Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yarn-error.log
 dist/
 /storybook-static/*
 build-storybook.log
+stats.html

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rollup-plugin-filesize": "^9.0.2",
     "rollup-plugin-peer-deps-external": "^2.2.3",
     "rollup-plugin-terser": "^6.1.0",
+    "rollup-plugin-visualizer": "^4.1.1",
     "storybook": "^5.3.19",
     "ts-jest": "^26.4.0",
     "typescript": "^3.9.7"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import externalGlobals from 'rollup-plugin-external-globals';
 import pkg from './package.json';
+import visualizer from 'rollup-plugin-visualizer';
 
 const extensions = [...DEFAULT_EXTENSIONS, '.ts', '.tsx'];
 
@@ -43,6 +44,9 @@ const configs = [
             terser(),
             filesize(),
             externalGlobals(globals),
+            // Note, visualizer is useful for *relative* sizes, but reports
+            // pre-minification.
+            visualizer({ gzipSize: true }),
         ],
     },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,6 @@ import filesize from 'rollup-plugin-filesize';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
-import alias from '@rollup/plugin-alias';
 import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import externalGlobals from 'rollup-plugin-external-globals';
@@ -17,39 +16,35 @@ const globals = {
     '@emotion/core': 'guardian.automat.emotionCore',
 };
 
-const configs = [['./index.ts', './dist/index.js']].map(([input, file]) => ({
-    input: input,
-    output: [
-        {
-            file: pkg.main,
-            format: 'cjs',
-        },
-        {
-            file: pkg.module,
-            format: 'esm',
-            sourcemap: false,
-        },
-    ],
-    external: (id) => Object.keys(globals).some((key) => id == key),
-    plugins: [
-        peerDepsExternal(),
-        // alias({
-        //   entries: [
-        //     { find: "react", replacement: "preact-x/compat" },
-        //     { find: "react-dom", replacement: "preact-x/compat" },
-        //   ],
-        // }),
-        resolve({ extensions: extensions }),
-        commonjs(),
-        replace({ 'process.env.NODE_ENV': '"production"' }),
-        babel({
-            babelHelpers: 'bundled',
-            extensions: extensions,
-        }),
-        terser(),
-        filesize(),
-        externalGlobals(globals),
-    ],
-}));
+const configs = [
+    {
+        input: './index.ts',
+        output: [
+            {
+                file: pkg.main,
+                format: 'cjs',
+            },
+            {
+                file: pkg.module,
+                format: 'esm',
+                sourcemap: false,
+            },
+        ],
+        external: (id) => Object.keys(globals).some((key) => id == key),
+        plugins: [
+            peerDepsExternal(),
+            resolve({ extensions: extensions }),
+            commonjs(),
+            replace({ 'process.env.NODE_ENV': '"production"' }),
+            babel({
+                babelHelpers: 'bundled',
+                extensions: extensions,
+            }),
+            terser(),
+            filesize(),
+            externalGlobals(globals),
+        ],
+    },
+];
 
 export default configs;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6174,6 +6174,11 @@ escalade@^3.0.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
   integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
 
+escape-goat@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
+  integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
+
 escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -10608,6 +10613,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
+nanoid@^3.0.1:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
+  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -11171,6 +11181,14 @@ open@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/open/-/open-7.1.0.tgz#68865f7d3cb238520fa1225a63cf28bcf8368a1c"
   integrity sha512-lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
+open@^7.0.3:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.2.1.tgz#07b0ade11a43f2a8ce718480bdf3d7563a095195"
+  integrity sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
@@ -12068,6 +12086,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pupa@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.0.1.tgz#dbdc9ff48ffbea4a26a069b6f9f7abb051008726"
+  integrity sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==
+  dependencies:
+    escape-goat "^2.0.0"
 
 q@^1.1.2:
   version "1.5.1"
@@ -13001,6 +13026,17 @@ rollup-plugin-terser@^6.1.0:
     jest-worker "^26.0.0"
     serialize-javascript "^3.0.0"
     terser "^4.7.0"
+
+rollup-plugin-visualizer@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-4.1.1.tgz#b8b18db0aa4b0e3b2af583399fa9d7e3f5a61808"
+  integrity sha512-aQBukhj8T+1BcOjD/5xB3+mZSSzHIVT+WpQDDEVpmPCkILVX0J7NPOuKEvKIXU+iZLvF7B5/wJA4+wxuH7FNew==
+  dependencies:
+    nanoid "^3.0.1"
+    open "^7.0.3"
+    pupa "^2.0.0"
+    source-map "^0.7.3"
+    yargs "^15.0.0"
 
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
@@ -15334,7 +15370,7 @@ yargs@^13.2.2, yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^15.3.1:
+yargs@^15.0.0, yargs@^15.3.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
## What does this change?

This outputs a `stats.html` file when building the package so we can see what our bundle is made up of.

Also includes a tidy up of the rollup config (separate commit).

<img width="1440" alt="Screenshot 2020-09-25 at 10 09 20" src="https://user-images.githubusercontent.com/379839/94249178-6d38ef80-ff17-11ea-8ff1-2f65b6ca5ba5.png">
