### PR TITLE
Updated README to include more information on testing and updating the NPM module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ $ yarn install --force
 
 [`yarn link`]: https://classic.yarnpkg.com/en/docs/cli/link/
 
-NOTE: Ensure you build this library before adding it locally to your project,
+NOTE:
+- Ensure you build this library before adding it locally to your project,
 by running `yarn build`. You can also use `yarn watch` to build automatically
 when the source code is changed.
+
+- The external project (e.g. DCR/frontend) may not be set up to watch changes from linked modules. Removing: `ignored: /node_modules/,` from [`watchOptions`](https://github.com/guardian/frontend/blob/main/dev/watch.js#L30) in frontend will enable `make watch` (in frontend) to also track changes to `braze-components`.
 
 ## Publishing to NPM
 
@@ -58,3 +61,6 @@ This will:
 - Interactively ask for a new version number (and create a commit for the
   version change in package.json)
 - Publish the new release to NPM
+- Push a single commit to your local version of this repository
+
+Once a new version has been published, you can push the single commit straight to this repo's `main` branch. This should only update the `version` field in [package.json](https://github.com/guardian/braze-components/blob/main/package.json).

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ This will:
 - Interactively ask for a new version number (and create a commit for the
   version change in package.json)
 - Publish the new release to NPM
-- Push a single commit to your local version of this repository
+- Push a single commit to your local version of this repository, updating the version number in `package.json`
 
 Once a new version has been published, you can push the single commit straight to this repo's `main` branch. This should only update the `version` field in [package.json](https://github.com/guardian/braze-components/blob/main/package.json).


### PR DESCRIPTION
Added some useful info for testing in Frontend regarding `make watch` tracking the linked module.

Also added an instruction for updating `main` when a new version of the NPM module is published.