### PR TITLE
Handle click tracking in the component

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@emotion/babel-preset-css-prop": "^10.0.27",
+    "@guardian/types": "^0.4.5",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",

--- a/src/BrazeMessage.test.tsx
+++ b/src/BrazeMessage.test.tsx
@@ -17,7 +17,8 @@ describe('BrazeMessage', () => {
         render(
             <BrazeMessage
                 componentName={'ExampleComponent'}
-                onButtonClick={jest.fn}
+                logButtonClickWithBraze={jest.fn()}
+                submitComponentEvent={jest.fn()}
                 brazeMessageProps={{}}
             />,
         );
@@ -35,7 +36,8 @@ describe('BrazeMessage', () => {
         render(
             <BrazeMessage
                 componentName={'NoSuchComponent'}
-                onButtonClick={jest.fn}
+                logButtonClickWithBraze={jest.fn()}
+                submitComponentEvent={jest.fn()}
                 brazeMessageProps={{}}
             />,
         );

--- a/src/BrazeMessage.tsx
+++ b/src/BrazeMessage.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { DigitalSubscriberAppBanner } from './DigitalSubscriberAppBanner';
+import { OphanComponentEvent } from '@guardian/types/ophan';
+import {
+    COMPONENT_NAME as DIGITAL_SUBSCRIBER_APP_BANNER_NAME,
+    DigitalSubscriberAppBanner,
+} from './DigitalSubscriberAppBanner';
+import { BrazeClickHandler } from './tracking';
 
 type BrazeMessageProps = {
     [key: string]: string | undefined;
 };
 
 type CommonComponentProps = {
-    onButtonClick: (buttonIndex: number) => void;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
     brazeMessageProps: BrazeMessageProps;
 };
 
@@ -15,17 +21,23 @@ type ComponentMapping = {
 };
 
 const COMPONENT_MAPPINGS: ComponentMapping = {
-    DigitalSubscriberAppBanner,
+    [DIGITAL_SUBSCRIBER_APP_BANNER_NAME]: DigitalSubscriberAppBanner,
 };
 
 export type Props = {
-    onButtonClick: (buttonIndex: number) => void;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
     componentName: string;
     brazeMessageProps: BrazeMessageProps;
 };
 
 export const buildBrazeMessageComponent = (mappings: ComponentMapping): React.FC<Props> => {
-    const BrazeMessageComponent = ({ onButtonClick, componentName, brazeMessageProps }: Props) => {
+    const BrazeMessageComponent = ({
+        logButtonClickWithBraze,
+        submitComponentEvent,
+        componentName,
+        brazeMessageProps,
+    }: Props) => {
         const ComponentToRender = mappings[componentName];
 
         if (!ComponentToRender) {
@@ -34,7 +46,8 @@ export const buildBrazeMessageComponent = (mappings: ComponentMapping): React.FC
 
         return (
             <ComponentToRender
-                onButtonClick={onButtonClick}
+                logButtonClickWithBraze={logButtonClickWithBraze}
+                submitComponentEvent={submitComponentEvent}
                 brazeMessageProps={brazeMessageProps}
             />
         );

--- a/src/DigitalSubscriberAppBanner.stories.tsx
+++ b/src/DigitalSubscriberAppBanner.stories.tsx
@@ -17,8 +17,11 @@ export const defaultStory = (): ReactElement => {
         <StorybookWrapper>
             <BrazeMessage
                 componentName={text('componentName', 'DigitalSubscriberAppBanner')}
-                onButtonClick={(buttonId) => {
-                    console.log(`Button ${buttonId} clicked`);
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
                 }}
                 brazeMessageProps={{
                     header: text('header', 'A note to our digital subscribers'),

--- a/src/DigitalSubscriberAppBanner.test.tsx
+++ b/src/DigitalSubscriberAppBanner.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { DigitalSubscriberAppBanner } from './DigitalSubscriberAppBanner';
+
+describe('DigitalSubscriberAppBanner', () => {
+    describe('when a button is clicked', () => {
+        const baseProps = () => ({
+            logButtonClickWithBraze: jest.fn(),
+            submitComponentEvent: jest.fn(),
+            brazeMessageProps: {
+                header: 'A note to our digital subscribers',
+                body: 'Hi John, did you know...',
+            },
+        });
+
+        it('invokes logButtonClickWithBraze with the internal button ID', () => {
+            const logButtonClickWithBraze = jest.fn();
+            const { getByText } = render(
+                <DigitalSubscriberAppBanner
+                    {...baseProps()}
+                    logButtonClickWithBraze={logButtonClickWithBraze}
+                />,
+            );
+
+            fireEvent.click(getByText('Ok, got it'));
+
+            expect(logButtonClickWithBraze).toHaveBeenCalledWith(0);
+        });
+
+        it('invokes submitComponentEvent with correct data', () => {
+            const logButtonClickWithOphan = jest.fn();
+            const { getByText } = render(
+                <DigitalSubscriberAppBanner
+                    {...baseProps()}
+                    submitComponentEvent={logButtonClickWithOphan}
+                />,
+            );
+
+            fireEvent.click(getByText('Ok, got it'));
+
+            expect(logButtonClickWithOphan).toHaveBeenCalledWith({
+                component: {
+                    componentType: 'RETENTION_ENGAGEMENT_BANNER',
+                    id: 'DigitalSubscriberAppBanner',
+                },
+                action: 'CLICK',
+                value: '1',
+            });
+        });
+
+        it('closes the banner', () => {
+            const props = baseProps();
+            const { container, getByText } = render(<DigitalSubscriberAppBanner {...props} />);
+
+            fireEvent.click(getByText('Ok, got it'));
+
+            // Closing the banner means nothing is rendered
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('closes the banner even if the callback throws an error', () => {
+            const props = baseProps();
+            const logButtonClickWithBraze = () => {
+                throw new Error('Something went wrong');
+            };
+            const { container, getByText } = render(
+                <DigitalSubscriberAppBanner
+                    {...props}
+                    logButtonClickWithBraze={logButtonClickWithBraze}
+                />,
+            );
+
+            fireEvent.click(getByText('Ok, got it'));
+
+            // Closing the banner means nothing is rendered
+            expect(container.firstChild).toBeNull();
+        });
+    });
+});

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,0 +1,3 @@
+type BrazeClickHandler = (internalButtonId: number) => void;
+
+export { BrazeClickHandler };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,6 +1299,13 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.2.0.tgz#c4cc2f8a96dbba1ca0aa9f9ab379f6a4e0a3be16"
   integrity sha512-WBIv2Z/aw/jnxUMbZaJ/+cnlfLrqRdSakZsDbopJnSospKZiaphVHAOEkA+5tQaAP1M4C0Z+PpfrEf7iKfsO2w==
 
+"@guardian/types@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-0.4.5.tgz#e603f23908f436309fc9caa9149468f2c8db4202"
+  integrity sha512-OJGK5x5UTQlmdauPAXJW00ZJVkeqgsdaixwkvBnM0D7BQWSAao/NM3nxLiX8OYaksXl4mkYhO4+XmJlVy29Y6Q==
+  dependencies:
+    typescript "^3.8.3"
+
 "@iarna/cli@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@iarna/cli/-/cli-1.2.0.tgz#0f7af5e851afe895104583c4ca07377a8094d641"
@@ -14482,7 +14489,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.7:
+typescript@^3.8.3, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
## What does this change?

The platform is expected to provide an implementation of `submitComponentEvent` to the component as a prop. We can then use this whenever we want to add Ophan tracking in the component. Initially we'll be using it for tracking clicks. This This reduces duplication and arguably makes it easier to test.

Note that I'm pointing to a GitHub branch for `@guardian/types` to get the Ophan types. When (if!) that branch is merged we can switch to getting from NPM.