### PR TITLE
Make @guardian/types a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@emotion/babel-preset-css-prop": "^10.0.27",
-    "@guardian/types": "^0.4.5",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",
@@ -74,6 +73,7 @@
     "@guardian/src-foundations": "^2.1.0",
     "@guardian/src-grid": "^2.2.0",
     "@guardian/src-icons": "^2.2.0",
+    "@guardian/types": "^0.4.5",
     "emotion-theming": "^10.0.19"
   }
 }


### PR DESCRIPTION
Not a dev dependency. I ran into an issue where the version specified by DCR was `^0.4.4` but `@guardian/braze-components` wants `^0.4.5`. I’d thought that would resolve to `0.4.5` in DCR but I think yarn doesn’t take into account the version required by `braze-components` because it’s a dev dependency. We ship TypeScript types with this package, which refer to types in `@guardian/types`, so I think a direct dependency makes sense. I think a peer dependency would also work, but this feels simpler so trying this approach first.