### PR TITLE
Run Local Storybook on a gutools domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 /storybook-static/*
 build-storybook.log
 stats.html
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+tap "guardian/devtools"
+brew "guardian/devtools/dev-nginx"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ frontend.
 
 ## Development
 
+### Local Setup
+
+```
+$ bin/setup
+```
+
 ### Storybook
 
 We use Storybook when building components. Run Storybook with:

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=${DIR}/..
+
+brew bundle --file=${ROOT_DIR}/Brewfile
+
+dev-nginx setup-app ${ROOT_DIR}/nginx/nginx-mappings.yml
+
+yarn install

--- a/nginx/nginx-mappings.yml
+++ b/nginx/nginx-mappings.yml
@@ -1,0 +1,4 @@
+name: braze-storybook
+mappings:
+    - prefix: braze-storybook
+      port: 6016

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "jest",
     "tsc": "tsc  --noEmit",
     "publishToNPM": "yarn build && yarn publish --access public",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -p 6016",
     "build-storybook": "build-storybook",
     "prepare": "install-peers",
     "lint": "eslint . --ext .ts,.tsx"


### PR DESCRIPTION
## What does this change?

Add support for running Storybook locally on a gutools domain. This is so that we can embed Grid into the story for image handling (coming in a future PR).

## How to test

* Run storybook locally
* Visit https://braze-storybook.local.dev-gutools.co.uk/

## Caveats

* There are still some items to figure out which we can tackle in future PRs. We'll want to access the deployed version of Storybook via a gutools domain too (and this will need to embed prod Grid). Probably by building storybook and deploying to an S3 bucket.

* Running `yarn storybook` still opens http://localhost:6016. This is because it's non-trivial to override the URL which storybook opens in the browser. You can tell Storybook not to open in a browser with the `--ci` flag, but because the Storybook server is a daemon it's hard to know when to then `open https://braze-storybook.local.dev-gutools.co.uk/`. If you background the process the page opens before Storybook has finished building and a 503 is returned. I'm experimenting with some kind of client side redirect to make this work.