### PR TITLE
Integrate Grid Picker with Storybook

### DIFF
--- a/.storybook/grid/GridPanel.tsx
+++ b/.storybook/grid/GridPanel.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { AddonPanel } from '@storybook/components';
+import { useChannel } from '@storybook/api';
+import { STORY_CHANGED } from '@storybook/core-events';
+import { API } from '@storybook/api';
+import type { IframePostMessage } from '@guardian/grid-client';
+import { styles } from './gridStyles';
+import { INITIAL_IMAGE_EVENT, IMAGE_SELECTED_EVENT } from './withGrid';
+import { GRID_URL } from '../../src/utils/env';
+
+const isValidMessage = (data: IframePostMessage) =>
+    data?.crop?.data && data?.image?.data && data?.crop?.data?.assets?.length > 0;
+
+type Props = {
+    active: boolean;
+    api: API;
+};
+
+export const GridPanel = ({ api, active }: Props) => {
+    const emit = useChannel({});
+    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+    const [selectedImage, setSelectedImage] = useState<string | undefined>();
+    const activeButton = useRef(null);
+
+    const onMessage = (event) => {
+        if (event.origin !== GRID_URL) {
+            return;
+        }
+
+        const data: IframePostMessage = event.data;
+
+        if (!isValidMessage(data)) {
+            console.log("Image data isn't valid!", data);
+            return;
+        }
+
+        const cropAssets = data.crop.data.assets;
+        const cropUrl = cropAssets[cropAssets.length - 1]?.secureUrl;
+
+        if (!cropUrl) {
+            return null;
+        }
+        setSelectedImage(cropUrl.toString());
+        emit(IMAGE_SELECTED_EVENT, cropUrl);
+
+        setIsModalOpen(false);
+    };
+
+    useEffect(() => {
+        if (isModalOpen) {
+            window.addEventListener('message', onMessage, false);
+        } else {
+            window.removeEventListener('message', onMessage, false);
+        }
+
+        return () => window.removeEventListener('message', onMessage, false);
+    }, [isModalOpen]);
+
+    useEffect(() => {
+        // This panel is reused across stories, so reset when the story is changed
+        const onStoryChanged = () => {
+            setIsModalOpen(false);
+            setSelectedImage(undefined);
+        };
+
+        const onInitialImage = (initialImage) => {
+            setSelectedImage(initialImage);
+        };
+
+        api.on(STORY_CHANGED, onStoryChanged);
+        api.on(INITIAL_IMAGE_EVENT, onInitialImage);
+
+        return () => {
+            api.off(STORY_CHANGED, onStoryChanged);
+            api.off(INITIAL_IMAGE_EVENT, onInitialImage);
+        };
+    }, []);
+
+    return (
+        <AddonPanel active={active}>
+            <div>
+                <div css={styles.buttonRow}>
+                    <button
+                        css={isModalOpen ? styles.inactiveButton : styles.activeButton}
+                        ref={activeButton}
+                        onClick={() => {
+                            setIsModalOpen(true);
+                            activeButton.current.blur();
+                        }}
+                    >
+                        Select image
+                    </button>
+                    <button
+                        css={isModalOpen ? styles.activeButton : styles.inactiveButton}
+                        ref={activeButton}
+                        onClick={() => {
+                            setIsModalOpen(false);
+                            activeButton.current.blur();
+                        }}
+                    >
+                        Close Grid
+                    </button>
+                </div>
+
+                {selectedImage && (
+                    <div css={styles.resultRow}>
+                        <span css={styles.resultKey}>imageUrl:</span>
+                        <textarea css={styles.resultValue} value={selectedImage} readOnly={true} />
+                    </div>
+                )}
+
+                {isModalOpen && <GridModal />}
+            </div>
+        </AddonPanel>
+    );
+};
+
+const GridModal = () => (
+    <div css={styles.modal}>
+        <iframe css={styles.iframe} src={GRID_URL}></iframe>
+    </div>
+);

--- a/.storybook/grid/gridStyles.ts
+++ b/.storybook/grid/gridStyles.ts
@@ -1,0 +1,108 @@
+import { css } from '@emotion/core';
+
+const barHeight = "48px"
+
+export const styles = {
+    modal: css`
+        position: absolute;
+        top: ${barHeight};
+        left: 0;
+        width: 100%;
+        height: calc(100% - ${barHeight});
+    `,
+    iframe: css`
+        width: 100%;
+        height: 100%;
+    `,
+    buttonRow: css`
+        display: flex;
+        border-bottom: 1px solid rgba(0,0,0,.1);
+        margin: 0 15px;
+        padding: 8px 0;
+        justify-content: space-between;
+    `,
+    activeButton: css`
+        border: 0;
+        cursor: pointer;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        transition: all 150ms ease-out;
+        transform: translate3d(0,0,0);
+        vertical-align: top;
+        white-space: nowrap;
+        margin: 0;
+        font-size: 12px;
+        font-weight: 700;
+        line-height: 1;
+        background: #fafafa;
+        color: #333333;
+        box-shadow: rgba(0,0,0,.1) 0 0 0 1px inset;
+        border-radius: 4px;
+        padding: 10px 16px;
+        display: inline;
+        overflow: visible;
+    `,
+    resultRow: css`
+        display: flex;
+        border-bottom: 1px solid rgba(0,0,0,.1);
+        margin: 0 15px;
+        padding: 8px 0;
+    `,
+    resultKey: css`
+        min-width: 100px;
+        font-weight: 700;
+        margin-right: 15px;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        line-height: 16px;
+        box-sizing: border-box;
+    `,
+    resultValue: css`
+        appearance: none;
+        border: 0 none;
+        box-sizing: inherit;
+        display: block;
+        margin: 0;
+        background: #FFFFFF;
+        padding: 6px 10px;
+        font-size: 13px;
+        position: relative;
+        transition: all 200ms ease-out;
+        color: #333333;
+        box-shadow: rgba(0,0,0,.1) 0 0 0 1px inset;
+        border-radius: 4px;
+        line-height: 20px;
+        flex: 1;
+        text-align: left;
+        overflow: visible;
+        height: 52px;
+    `,
+    inactiveButton: css`
+        border: 0;
+        cursor: no-drop;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        transition: all 150ms ease-out;
+        transform: translate3d(0,0,0);
+        vertical-align: top;
+        white-space: nowrap;
+        margin: 0;
+        font-size: 12px;
+        font-weight: 700;
+        line-height: 1;
+        background: #dddddd;
+        color: #aaaaaa;
+        box-shadow: rgba(0,0,0,.1) 0 0 0 1px inset;
+        border-radius: 4px;
+        border-bottom-style: none;
+        padding: 10px 16px;
+        display: inline;
+        overflow: visible;
+        &:focus {
+            outline: none !important;
+        }
+    `,
+};

--- a/.storybook/grid/register.js
+++ b/.storybook/grid/register.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { addons, types } from '@storybook/addons';
+import { GridPanel } from './GridPanel';
+
+const GRID_ADDON_ID = 'gridAddon';
+const GRID_PANEL_ID = `${GRID_ADDON_ID}/panel`;
+
+addons.register(GRID_ADDON_ID, (api) => {
+    addons.add(GRID_PANEL_ID, {
+        title: 'Grid Image Picker',
+        type: types.PANEL,
+        render: ({ active, key }) => <GridPanel api={api} active={active} key={key} />,
+        paramKey: 'grid', // This is the key under which parameters are expected in the addon config
+    });
+});

--- a/.storybook/grid/withGrid.tsx
+++ b/.storybook/grid/withGrid.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import addons from '@storybook/addons';
+import { makeDecorator } from '@storybook/addons';
+import { STORY_CHANGED, FORCE_RE_RENDER } from '@storybook/core-events';
+
+let gridValue;
+export const IMAGE_SELECTED_EVENT = 'IMAGE_SELECTED_EVENT';
+export const INITIAL_IMAGE_EVENT = 'INITIAL_IMAGE_EVENT';
+
+export const grid = (defaultValue) => {
+    if (!gridValue) {
+        addons.getChannel().emit(INITIAL_IMAGE_EVENT, defaultValue);
+    }
+
+    return gridValue || defaultValue;
+};
+
+const forceReRender = () => {
+    addons.getChannel().emit(FORCE_RE_RENDER);
+};
+
+const onStoryChanged = () => {
+    gridValue = undefined;
+};
+
+const onImageSelected = (payload) => {
+    gridValue = payload;
+    forceReRender();
+};
+
+const disconnectEventListeners = () => {
+    const channel = addons.getChannel();
+
+    channel.removeListener(IMAGE_SELECTED_EVENT, onImageSelected);
+    channel.removeListener(STORY_CHANGED, onStoryChanged);
+};
+
+const connectEventListeners = () => {
+    const channel = addons.getChannel();
+
+    channel.on(IMAGE_SELECTED_EVENT, onImageSelected);
+    channel.on(STORY_CHANGED, onStoryChanged);
+
+    return disconnectEventListeners;
+};
+
+export const withGrid = makeDecorator({
+    name: 'withGrid',
+    parameterName: 'grid',
+    wrapper: (storyFn, context, { parameters }) => {
+        useEffect(connectEventListeners, []);
+
+        return storyFn(context);
+    },
+});

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,5 +5,10 @@ module.exports = {
         process.env.NODE_ENV === 'development'
             ? ['../src/**/*.stories.tsx']
             : ['../src/!(AppBanner)/*.stories.tsx'],
-    addons: ['@storybook/addon-knobs', '@storybook/addon-viewport', './gu-preview/register.js'],
+    addons: [
+        '@storybook/addon-knobs',
+        '@storybook/addon-viewport',
+        './gu-preview/register.js',
+        './grid/register.js',
+    ],
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,60 +1,62 @@
-import { addParameters } from "@storybook/react";
-import { breakpoints } from "@guardian/src-foundations";
-
+import { addParameters } from '@storybook/react';
+import { breakpoints } from '@guardian/src-foundations';
 
 const viewportMeta = {
-  mobile: {
-    name: "Mobile",
-    type: "mobile",
-  },
-  mobileMedium: {
-    name: "Mobile Medium",
-    type: "mobile",
-  },
-  mobileLandscape: {
-    name: "Mobile Landscape",
-    type: "mobile",
-  },
-  phablet: {
-    name: "Phablet",
-    type: "mobile",
-  },
-  tablet: {
-    name: "Tablet",
-    type: "tablet",
-  },
-  desktop: {
-    name: "Desktop",
-    type: "desktop",
-  },
-  leftCol: {
-    name: "Left Col",
-    type: "desktop",
-  },
-  wide: {
-    name: "Wide",
-    type: "desktop",
-  },
+    mobile: {
+        name: 'Mobile',
+        type: 'mobile',
+    },
+    mobileMedium: {
+        name: 'Mobile Medium',
+        type: 'mobile',
+    },
+    mobileLandscape: {
+        name: 'Mobile Landscape',
+        type: 'mobile',
+    },
+    phablet: {
+        name: 'Phablet',
+        type: 'mobile',
+    },
+    tablet: {
+        name: 'Tablet',
+        type: 'tablet',
+    },
+    desktop: {
+        name: 'Desktop',
+        type: 'desktop',
+    },
+    leftCol: {
+        name: 'Left Col',
+        type: 'desktop',
+    },
+    wide: {
+        name: 'Wide',
+        type: 'desktop',
+    },
 };
 const viewportEntries = Object.entries(breakpoints).map(([name, width]) => {
-  return [
-    name,
-    {
-      name: viewportMeta[name].name,
-      styles: {
-        width: `${width}px`,
-        height: "100%",
-      },
-      type: viewportMeta[name].type,
-    },
-  ];
+    return [
+        name,
+        {
+            name: viewportMeta[name].name,
+            styles: {
+                width: `${width}px`,
+                height: '100%',
+            },
+            type: viewportMeta[name].type,
+        },
+    ];
 });
 const viewports = Object.fromEntries(viewportEntries);
 
 addParameters({
-  viewport: {
-    viewports,
-    defaultViewport: "responsive",
-  },
-  layout: 'fullscreen'
+    viewport: {
+        viewports,
+        defaultViewport: 'responsive',
+    },
+    layout: 'fullscreen',
+    grid: {
+        disabled: true,
+    },
 });

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@emotion/babel-preset-css-prop": "^10.0.27",
+    "@guardian/grid-client": "^1.1.1",
     "@guardian/types": "^0.4.5",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",

--- a/src/AppBanner/index.stories.tsx
+++ b/src/AppBanner/index.stories.tsx
@@ -3,14 +3,18 @@ import { withKnobs, text } from '@storybook/addon-knobs';
 import { BrazeMessage } from '../BrazeMessage';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { knobsData } from '../utils/knobsData';
+import { withGrid, grid } from '../../.storybook/grid/withGrid';
 
 export default {
     component: 'AppBanner',
     title: 'Components/AppBanner',
-    decorators: [withKnobs],
+    decorators: [withGrid, withKnobs],
     parameters: {
         knobs: {
             escapeHTML: false, // Block HTML escaping, preventing double-escaping of imgUrl special characters in Storybook
+        },
+        grid: {
+            disabled: false,
         },
     },
 };
@@ -24,8 +28,7 @@ export const defaultStory = (): ReactElement => {
         'Hi John, did you know that as a Guardian digital subscriber you can enjoy an enhanced experience of our quality, independent journalism on all your devices, including The Guardian Live app.',
     );
     const componentName = text('componentName', 'AppBanner');
-    const imageUrl = text(
-        'imageUrl',
+    const imageUrl = grid(
         'https://i.guim.co.uk/img/media/de6813b4dd9b9805a2d14dd6af14ae2b48e2e19e/0_0_930_520/930.png?width=930&quality=60&s=a7d81978655765847246c8d4d0cd0e7f',
     );
     const cta = text('cta', 'Search for "Guardian live news"');
@@ -53,5 +56,3 @@ export const defaultStory = (): ReactElement => {
         </StorybookWrapper>
     );
 };
-
-defaultStory.story = { name: 'App Banner' };

--- a/src/DigitalSubscriberAppBanner/index.stories.tsx
+++ b/src/DigitalSubscriberAppBanner/index.stories.tsx
@@ -25,19 +25,21 @@ export const defaultStory = (): ReactElement => {
 
     return (
         <StorybookWrapper>
-            <BrazeMessage
-                componentName={componentName}
-                logButtonClickWithBraze={(internalButtonId) => {
-                    console.log(`Button with internal ID ${internalButtonId} clicked`);
-                }}
-                submitComponentEvent={(componentEvent) => {
-                    console.log('submitComponentEvent called with: ', componentEvent);
-                }}
-                brazeMessageProps={{
-                    header: header,
-                    body: body,
-                }}
-            />
+            <>
+                <BrazeMessage
+                    componentName={componentName}
+                    logButtonClickWithBraze={(internalButtonId) => {
+                        console.log(`Button with internal ID ${internalButtonId} clicked`);
+                    }}
+                    submitComponentEvent={(componentEvent) => {
+                        console.log('submitComponentEvent called with: ', componentEvent);
+                    }}
+                    brazeMessageProps={{
+                        header: header,
+                        body: body,
+                    }}
+                />
+            </>
         </StorybookWrapper>
     );
 };

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,7 @@
+const isDevelopment = (): boolean => process.env.NODE_ENV === 'development';
+
+const GRID_URL = isDevelopment()
+    ? 'https://media.test.dev-gutools.co.uk'
+    : 'https://media.gutools.co.uk';
+
+export { isDevelopment, GRID_URL };

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,4 +1,9 @@
-const ALLOWED_HOSTS = ['https://media.guim.co.uk/', 'https://i.guim.co.uk/'];
+import { isDevelopment } from './env';
 
-export const isImageUrlAllowed = (imageUrl: string): boolean =>
-    ALLOWED_HOSTS.some((host) => imageUrl.startsWith(host));
+const ALLOWED_HOSTS = ['https://media.guim.co.uk/', 'https://i.guim.co.uk/'];
+const ALLOWED_DEV_HOSTS = [...ALLOWED_HOSTS, 'https://s3-eu-west-1.amazonaws.com/'];
+
+export const isImageUrlAllowed = (imageUrl: string): boolean => {
+    const allowedHosts = isDevelopment() ? ALLOWED_DEV_HOSTS : ALLOWED_HOSTS;
+    return allowedHosts.some((host) => imageUrl.startsWith(host));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,17 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@guardian/grid-client@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/grid-client/-/grid-client-1.1.1.tgz#c445d37db9a75e9c3e53d79dc02ab0cbfed1ed10"
+  integrity sha512-pNZhe1/9mwvOqkcT5yOYTZdrXY+qgoEfjjl6ixw13020MOXmO9LoSDnJVqSjpfN9DH/WhpJ82pxLCIq6i5xEhQ==
+  dependencies:
+    fp-ts "^2.8.2"
+    io-ts "^2.2.10"
+    io-ts-types "^0.5.10"
+    monocle-ts "^2.3.3"
+    newtype-ts "^0.3.4"
+
 "@guardian/src-button@2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-2.4.0.tgz#44c7300fea0c78e09ea67deae67fed56aea3b820"
@@ -6680,6 +6691,11 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
+fp-ts@^2.8.2:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.8.5.tgz#1b4247081ea066cc152b48a55a0bc13c30828701"
+  integrity sha512-g6do+Q/IQsxgsd2qU6+QnAbZaPR533seIbFyLGqWSxhNX4+F+cY37QdaYmMUOzekLOv/yg/2f15tc26tzDatgw==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -7618,6 +7634,16 @@ invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
+
+io-ts-types@^0.5.10:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/io-ts-types/-/io-ts-types-0.5.12.tgz#270487f6e0adfe0a597ca14e50fbab287e4bb266"
+  integrity sha512-8IC96BJBTMeHFIikM3Mh5poyl2NA6pgF1ncWBktrpS1xfCdoRZQeSWPDcUaiR8T8jYWfAYOt/KEcIsw2e1fufw==
+
+io-ts@^2.2.10:
+  version "2.2.12"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.12.tgz#b840f2da4c2a6c8a4d8ab48122914672bfb22bab"
+  integrity sha512-pZh43E3xs1RUmv3voC58Mbb6Ihjo3UdDU6WWi578Zpe2BxVue1SlSQCioSymZxk9HoXa370nSfFzp5LrLA2F8g==
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -9897,6 +9923,11 @@ moment@^2.18.1:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+monocle-ts@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.3.3.tgz#1e6d83dcf42bcb96b74fdda07813c2a47ec6cfa4"
+  integrity sha512-pcQyauWO2vapxyZgbhTd73Dv8TmTELx1rL81bvrtPO2sUYTi1MIHmw3j/iMyeNaJwTmnGNAjqJpYV8Gq1Eu68g==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -9970,6 +10001,11 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+newtype-ts@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/newtype-ts/-/newtype-ts-0.3.4.tgz#65c74b7d5195edaa9abfcdba6549a33a5c0e298d"
+  integrity sha512-lFJnWAt0oXX1j1ErNy9RU5+FPNtVyzugHW2MchaaMiOeeS9LEmqAAOqyHPFQ0Uw895jStSYGSCslrByzYxFJYQ==
 
 next-tick@~1.0.0:
   version "1.0.0"
@@ -11897,14 +11933,6 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2:
-  version "1.18.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
-  integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
-  dependencies:
-    is-core-module "^2.0.0"
-    path-parse "^1.0.6"
-
-resolve@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
   integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==


### PR DESCRIPTION
## What does this change?

Builds on top of #44 by integrating with Grid, allowing the marketing user to select an image from Grid instead of specifying the image manually. As with the other configurable elements, the marketing user would then transfer these to Braze as key/value pairs when configuring an in-app message.

https://trello.com/c/4QSxdwus/994-integrate-grid-picker-with-storybook

Outstanding items, which could be tackled in future PRs:

* Hosted storybooks are still on Chromatic, where the grid picker won't load because of the content security policy. They need to be moved to a gutools.co.uk domain.
* We aren't being smart about which crop size to use, we simply selected the last one on the list. We've talked about extending this to generate a `i.guim.co.uk` URL from the `media.guim.co.uk` url returned by Grid. If we did that I'd think we'd use the master crop and then apply our own quality and size params to the i.guim url.
* Known issue where the currently selected image is reset when the browser window is resized below a certain width.
* Running storybook locally with `yarn storybook` opens on localhost:6016 where the grid picker won't work, again because of the CSP issue mentioned above. You have to visit https://braze-storybook.local.dev-gutools.co.uk/ manually.
* You must have already auth'd with Grid to be able to use the picker in storybook.

## Images

![Screenshot 2020-11-20 at 16 44 33](https://user-images.githubusercontent.com/379839/99826286-0f5c0900-2b50-11eb-8e75-21397be4ab69.png)

