### PR TITLE
Update URL we use to preview the banner

### DIFF
--- a/.storybook/gu-preview/GuPreview.tsx
+++ b/.storybook/gu-preview/GuPreview.tsx
@@ -15,7 +15,7 @@ const IconButtonLabel = styled.div<{}>(({ theme }) => ({
 
 function constructPreviewUrl() {
     let baseUrl =
-        'https://www.theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey?';
+        'https://preview.gutools.co.uk/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey?';
 
     const theKnobs = knobsData.get();
 


### PR DESCRIPTION
## What does this change?

We no longer support using www so use preview instead.

See guardian/frontend#23311 and guardian/dotcom-rendering#2148.

## How to test

The little preview icon in storybook should now link to an article on preview.gutools.co.uk instead of www.theguardian.com.