### PR TITLE
Setup Cloudfront for Storybook

### DIFF
--- a/cloudformation-static-s3.yaml
+++ b/cloudformation-static-s3.yaml
@@ -10,7 +10,26 @@ Parameters:
         Default: braze-components
 
 Resources:
-    AppDataBucket:
+    WebrootAccessIdentityID:
+        Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+        Properties:
+            CloudFrontOriginAccessIdentityConfig:
+                Comment: !Sub Braze Components Storybook webroot CDN access
+
+    WebrootBucketPolicy:
+        Type: AWS::S3::BucketPolicy
+        Properties:
+            Bucket: !Ref StorybookAssetsBucket
+            PolicyDocument:
+                Statement:
+                    - Effect: Allow
+                      Action:
+                          - s3:GetObject
+                      Resource: !Sub arn:aws:s3:::${StorybookAssetsBucket}/*
+                      Principal:
+                          AWS: !Sub arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${WebrootAccessIdentityID}
+
+    StorybookAssetsBucket:
         Type: AWS::S3::Bucket
         Properties:
             BucketName: braze-components-storybook
@@ -21,3 +40,8 @@ Resources:
                   Value: targeted-experiences
                 - Key: Stack
                   Value: !Ref Stack
+
+Outputs:
+    WebrootAccessIdentityID:
+        Description: ID of CloudFront origin access identity for webroot bucket access
+        Value: !Ref WebrootAccessIdentityID

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,0 +1,64 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Braze Components Application
+
+Mappings:
+    Constants:
+        Stack:
+            Value: targeting
+        App:
+            Value: braze-components
+
+Parameters:
+    Stage:
+        Type: String
+    WebrootBucket:
+        Type: String
+    DomainName:
+        Type: String
+    TLSCert:
+        Type: String
+        Description: ARN of TLS certificate in US-EAST-1
+    WebrootAccessIdentityID:
+        Type: String
+        Description: ID of CloudFront origin access identity for webroot bucket access (check output of static-s3 stack)
+
+Resources:
+    CDN:
+        Type: AWS::CloudFront::Distribution
+        Properties:
+            DistributionConfig:
+                Aliases:
+                    - !Ref DomainName
+                Origins:
+                    - Id: !Sub braze-components-${Stage}
+                      DomainName: !Sub ${WebrootBucket}.s3.amazonaws.com
+                      OriginPath: !Sub /${Stage}/braze-components-storybook-static
+                      S3OriginConfig:
+                          OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${WebrootAccessIdentityID}
+                DefaultCacheBehavior:
+                    AllowedMethods: [HEAD, GET]
+                    CachedMethods: [HEAD, GET]
+                    MinTTL: 3600
+                    Compress: true
+                    ForwardedValues:
+                        QueryString: false
+                    TargetOriginId: !Sub braze-components-${Stage}
+                    ViewerProtocolPolicy: redirect-to-https
+                DefaultRootObject: index.html
+                CustomErrorResponses:
+                    - ErrorCachingMinTTL: 5
+                      ErrorCode: 404
+                PriceClass: PriceClass_100
+                Enabled: true
+                ViewerCertificate:
+                    AcmCertificateArn: !Ref TLSCert
+                    MinimumProtocolVersion: TLSv1
+                    SslSupportMethod: sni-only
+                HttpVersion: http2
+            Tags:
+                - Key: app
+                  Value: !FindInMap [Constants, App, Value]
+                - Key: stack
+                  Value: !FindInMap [Constants, Stack, Value]
+                - Key: stage
+                  Value: !Ref Stage


### PR DESCRIPTION
## What does this change?

Sets up Cloudfront with the relevant access permissions for Storybook in [prod](https://d24910mcsqu03e.cloudfront.net/) and [code](https://d63nzptxc4ib2.cloudfront.net/). We've requested custom domains for PROD and CODE but they aren't ready yet.

PR to setup Riff Raff to do the cloudformation to follow.