### PR TITLE
Special Edition Banner

### DIFF
--- a/src/BrazeMessage.tsx
+++ b/src/BrazeMessage.tsx
@@ -5,6 +5,10 @@ import {
     DigitalSubscriberAppBanner,
 } from './DigitalSubscriberAppBanner';
 import { COMPONENT_NAME as APP_BANNER_NAME, AppBanner } from './AppBanner';
+import {
+    COMPONENT_NAME as SPECIAL_EDITION_BANNER_NAME,
+    SpecialEditionBanner,
+} from './SpecialEditionBanner';
 import { BrazeClickHandler } from './utils/tracking';
 
 type BrazeMessageProps = {
@@ -24,6 +28,7 @@ type ComponentMapping = {
 const COMPONENT_MAPPINGS: ComponentMapping = {
     [DIGITAL_SUBSCRIBER_APP_BANNER_NAME]: DigitalSubscriberAppBanner,
     [APP_BANNER_NAME]: AppBanner,
+    [SPECIAL_EDITION_BANNER_NAME]: SpecialEditionBanner,
 };
 
 export type Props = {

--- a/src/SpecialEditionBanner/index.stories.tsx
+++ b/src/SpecialEditionBanner/index.stories.tsx
@@ -1,0 +1,52 @@
+import React, { ReactElement } from 'react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import { BrazeMessage } from '../BrazeMessage';
+import { StorybookWrapper } from '../utils/StorybookWrapper';
+import { knobsData } from '../utils/knobsData';
+
+export default {
+    component: 'SpecialEditionBanner',
+    title: 'Components/SpecialEditionBanner',
+    decorators: [withKnobs],
+    parameters: {
+        knobs: {
+            escapeHTML: false, // Block HTML escaping, preventing double-escaping of imgUrl special characters in Storybook
+        },
+    },
+};
+
+export const defaultStory = (): ReactElement => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const slotName = text('slotName', 'Banner');
+    const header = text('header', "A year you'd rather forget?");
+    const body = text(
+        'body',
+        "2020 has been a shocker of a year, but there were some bright spots shining through the gloom: untold heroism, invention, kindness, scientific breakthroughs, communal spirit and moments of great independent journalism. We've gathered it all for you in our latest special edition: The best of a bad year.",
+    );
+    const componentName = text('componentName', 'SpecialEditionBanner');
+
+    // This is to make the data available to the guPreview add-on:
+    knobsData.set({ header, body, componentName });
+
+    return (
+        <StorybookWrapper>
+            <>
+                <BrazeMessage
+                    componentName={componentName}
+                    logButtonClickWithBraze={(internalButtonId) => {
+                        console.log(`Button with internal ID ${internalButtonId} clicked`);
+                    }}
+                    submitComponentEvent={(componentEvent) => {
+                        console.log('submitComponentEvent called with: ', componentEvent);
+                    }}
+                    brazeMessageProps={{
+                        header: header,
+                        body: body,
+                    }}
+                />
+            </>
+        </StorybookWrapper>
+    );
+};
+
+defaultStory.story = { name: 'Special Edition Banner' };

--- a/src/SpecialEditionBanner/index.test.tsx
+++ b/src/SpecialEditionBanner/index.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { SpecialEditionBanner } from '.';
+
+describe('SpecialEditionBanner', () => {
+    describe('when a button is clicked', () => {
+        const baseProps = () => ({
+            logButtonClickWithBraze: jest.fn(),
+            submitComponentEvent: jest.fn(),
+            brazeMessageProps: {
+                header: 'Some header text',
+                body: 'Some body text',
+            },
+        });
+
+        it('invokes submitComponentEvent with correct data', () => {
+            const logButtonClickWithOphan = jest.fn();
+            const { getByText } = render(
+                <SpecialEditionBanner
+                    {...baseProps()}
+                    submitComponentEvent={logButtonClickWithOphan}
+                />,
+            );
+
+            fireEvent.click(getByText('Ok, got it'));
+
+            expect(logButtonClickWithOphan).toHaveBeenCalledWith({
+                component: {
+                    componentType: 'RETENTION_ENGAGEMENT_BANNER',
+                    id: 'SpecialEditionBanner',
+                },
+                action: 'CLICK',
+                value: '1',
+            });
+        });
+    });
+});

--- a/src/SpecialEditionBanner/index.tsx
+++ b/src/SpecialEditionBanner/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { AppBanner } from '../AppBanner';
+import type { OphanComponentEvent } from '@guardian/types/ophan';
+import type { BrazeClickHandler } from '../utils/tracking';
+
+export type Props = {
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    brazeMessageProps: {
+        header?: string;
+        body?: string;
+    };
+};
+
+export const COMPONENT_NAME = 'SpecialEditionBanner';
+const cta = 'Access it now in your Guardian Editions app';
+const imageUrl =
+    'https://i.guim.co.uk/img/media/c5323f4e7ee9b8fd532fea191b6cb1d69a070e62/0_0_930_520/930.png?quality=80&width=930&s=2a9c91520ce26e1e84e9c917b9132e94';
+
+export const SpecialEditionBanner: React.FC<Props> = ({
+    logButtonClickWithBraze,
+    submitComponentEvent,
+    brazeMessageProps: { header, body },
+}: Props) => (
+    <AppBanner
+        logButtonClickWithBraze={logButtonClickWithBraze}
+        submitComponentEvent={submitComponentEvent}
+        ophanComponentId={COMPONENT_NAME}
+        brazeMessageProps={{
+            header,
+            body,
+            cta,
+            imageUrl,
+        }}
+    />
+);


### PR DESCRIPTION
## What does this change?

Adds a new banner to support an editions app message for the end of the year. The turn around on this was tight so we've essentially duplicated `DigitalSubscriberAppBanner` changing the necessary elements.

## How to test

Storybook!

## Images

Note that the body text is likely to be made shorter (controlled by marketing in Braze):

![Screenshot 2020-12-18 at 09 57 59](https://user-images.githubusercontent.com/379839/102601089-9b455e80-4117-11eb-88c4-ab3a2962e86e.png)

![Screenshot 2020-12-18 at 09 58 25](https://user-images.githubusercontent.com/379839/102601135-a9937a80-4117-11eb-9af4-9effab0a36b5.png)