### PR TITLE
Bump @guardian/types to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@emotion/babel-preset-css-prop": "^10.0.27",
     "@guardian/grid-client": "^1.1.1",
     "@guardian/node-riffraff-artifact": "^0.1.9",
-    "@guardian/types": "^0.4.5",
+    "@guardian/types": "^1.1.0",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",

--- a/src/AppBanner/index.tsx
+++ b/src/AppBanner/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { Button, buttonReaderRevenueBrandAlt } from '@guardian/src-button';
 import { SvgCross, SvgInfo } from '@guardian/src-icons';
-import { OphanComponentEvent } from '@guardian/types/ophan';
+import { OphanComponentEvent } from '@guardian/types';
 
 import { AppStore } from '../assets/app-store';
 import { PlayStore } from '../assets/play-store';

--- a/src/BrazeMessage.tsx
+++ b/src/BrazeMessage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { OphanComponentEvent } from '@guardian/types/ophan';
+import { OphanComponentEvent } from '@guardian/types';
 import {
     COMPONENT_NAME as DIGITAL_SUBSCRIBER_APP_BANNER_NAME,
     DigitalSubscriberAppBanner,

--- a/src/DigitalSubscriberAppBanner/index.tsx
+++ b/src/DigitalSubscriberAppBanner/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AppBanner } from '../AppBanner';
-import type { OphanComponentEvent } from '@guardian/types/ophan';
+import type { OphanComponentEvent } from '@guardian/types';
 import type { BrazeClickHandler } from '../utils/tracking';
 
 export type Props = {

--- a/src/SpecialEditionBanner/index.tsx
+++ b/src/SpecialEditionBanner/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AppBanner } from '../AppBanner';
-import type { OphanComponentEvent } from '@guardian/types/ophan';
+import type { OphanComponentEvent } from '@guardian/types';
 import type { BrazeClickHandler } from '../utils/tracking';
 
 export type Props = {

--- a/src/TheGuardianIn2020Banner/index.tsx
+++ b/src/TheGuardianIn2020Banner/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { Button, buttonReaderRevenueBrandAlt, LinkButton } from '@guardian/src-button';
 import { SvgCross, SvgInfo } from '@guardian/src-icons';
-import { OphanComponentEvent } from '@guardian/types/ophan';
+import { OphanComponentEvent } from '@guardian/types';
 
 import { BrazeClickHandler } from '../utils/tracking';
 import { styles as commonStyles } from '../styles/bannerCommon';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,12 +1262,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.7.1.tgz#600ba5a16fd3857657360632caac1b2f38740829"
   integrity sha512-gQ7XrH3R++kZOXSK4e5ajRrUxNMgzQH7LiQ4HSYH51mJceh3YWtsc4934O5sCpJjJjhFiWGYubbg4BG14smUPg==
 
-"@guardian/types@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-0.4.5.tgz#e603f23908f436309fc9caa9149468f2c8db4202"
-  integrity sha512-OJGK5x5UTQlmdauPAXJW00ZJVkeqgsdaixwkvBnM0D7BQWSAao/NM3nxLiX8OYaksXl4mkYhO4+XmJlVy29Y6Q==
-  dependencies:
-    typescript "^3.8.3"
+"@guardian/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-1.1.0.tgz#5fa64d2156b4927d22a4b32c3503e493cd4aec53"
+  integrity sha512-NpYEHHfHyg/QpaAVdWHWVLlWmnowyZwa5/0Kkqk4xN+dMzLjrWL3CQfrBxVFILZgtz1IcMirMUHQb2zOjF3HBg==
 
 "@hapi/hoek@^9.0.0":
   version "9.1.0"
@@ -13706,7 +13704,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3, typescript@^3.9.7:
+typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
## What does this change?
Bumps the `@guardian/types` lib to `v1.1.0`

**This is a breaking change**

## Why?
The move to `v1` was a breaking change  to the way these types are exported and in order for DCR to upgrade (so that we can use const enums from /types) we need all dependencies to also bump their versions.