### PR TITLE
Bump @guardian/types to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@emotion/babel-preset-css-prop": "^10.0.27",
     "@guardian/grid-client": "^1.1.1",
     "@guardian/node-riffraff-artifact": "^0.1.9",
-    "@guardian/types": "^1.1.0",
+    "@guardian/types": "^2.0.0",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,10 +1262,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.7.1.tgz#600ba5a16fd3857657360632caac1b2f38740829"
   integrity sha512-gQ7XrH3R++kZOXSK4e5ajRrUxNMgzQH7LiQ4HSYH51mJceh3YWtsc4934O5sCpJjJjhFiWGYubbg4BG14smUPg==
 
-"@guardian/types@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-1.1.0.tgz#5fa64d2156b4927d22a4b32c3503e493cd4aec53"
-  integrity sha512-NpYEHHfHyg/QpaAVdWHWVLlWmnowyZwa5/0Kkqk4xN+dMzLjrWL3CQfrBxVFILZgtz1IcMirMUHQb2zOjF3HBg==
+"@guardian/types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-2.0.0.tgz#9567ee7638bae058799cb97b48a4078b48033d1c"
+  integrity sha512-0jR2FgTQVG9gO2a1IZwxFWi6UKxteBWPob5+zErbOrznN0u4Mf+9KgigMaNMWpZvkEdDhPAQl7ot5f6wW0wU5A==
 
 "@hapi/hoek@^9.0.0":
   version "9.1.0"


### PR DESCRIPTION
## What does this change?
Bumps `@guardian/types` to `v2.0.0`

## Why?
To support enums without having to manage const enums