### PR TITLE
use guardian/actions-setup-node

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,8 +9,7 @@ jobs:
               uses: actions/checkout@v1
 
             - name: Use Node.js
-              shell: bash -l {0}
-              run: nvm install
+              uses: guardian/actions-setup-node@main
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -9,8 +9,7 @@ jobs:
               uses: actions/checkout@v1
 
             - name: Use Node.js
-              shell: bash -l {0}
-              run: nvm install
+              uses: guardian/actions-setup-node@main
 
             - name: Install dependencies
               run: yarn install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,7 @@ jobs:
               uses: actions/checkout@v1
 
             - name: Use Node.js
-              shell: bash -l {0}
-              run: nvm install
+              uses: guardian/actions-setup-node@main
 
             - name: Install dependencies
               run: yarn install


### PR DESCRIPTION
## What does this change?

uses guardian/actions-setup-node

## Why?

using NVM here installs the correct version of node, but that instance of Node is not then used for the subsequent tasks. this ensures your NVM version is the one the tasks run with.