### PR TITLE
Add click tracking to GuardianIn2020 banner

### DIFF
--- a/src/TheGuardianIn2020Banner/index.tsx
+++ b/src/TheGuardianIn2020Banner/index.tsx
@@ -26,6 +26,26 @@ const catchAndLogErrors = (description: string, fn: () => void): void => {
     }
 };
 
+const logToBrazeAndOphan = (internalButtonId: number): void => {
+    catchAndLogErrors('ophanButtonClick', () => {
+        // Braze displays button id from 1, but internal representation is numbered from 0
+        // This ensures that the Button ID in Braze and Ophan will be the same
+        const externalButtonId = internalButtonId + 1;
+        submitComponentEvent({
+            component: {
+                componentType: 'RETENTION_ENGAGEMENT_BANNER',
+                id: ophanComponentId,
+            },
+            action: 'CLICK',
+            value: externalButtonId.toString(10),
+        });
+    });
+
+    catchAndLogErrors('brazeButtonClick', () => {
+        logButtonClickWithBraze(internalButtonId);
+    });
+};
+
 export const COMPONENT_NAME = 'TheGuardianIn2020Banner';
 
 const urlObject = new URL(
@@ -50,27 +70,7 @@ export const TheGuardianIn2020Banner: React.FC<Props> = ({
 }: Props) => {
     const [showBanner, setShowBanner] = useState(true);
 
-    const onClick = (internalButtonId: number): void => {
-        setShowBanner(false);
-
-        catchAndLogErrors('ophanButtonClick', () => {
-            // Braze displays button id from 1, but internal representation is numbered from 0
-            // This ensures that the Button ID in Braze and Ophan will be the same
-            const externalButtonId = internalButtonId + 1;
-            submitComponentEvent({
-                component: {
-                    componentType: 'RETENTION_ENGAGEMENT_BANNER',
-                    id: ophanComponentId,
-                },
-                action: 'CLICK',
-                value: externalButtonId.toString(10),
-            });
-        });
-
-        catchAndLogErrors('brazeButtonClick', () => {
-            logButtonClickWithBraze(internalButtonId);
-        });
-    };
+    const onClick = logToBrazeAndOphan;
 
     const onCloseClick = (
         evt: React.MouseEvent<HTMLButtonElement, MouseEvent>,
@@ -80,23 +80,7 @@ export const TheGuardianIn2020Banner: React.FC<Props> = ({
 
         setShowBanner(false);
 
-        catchAndLogErrors('ophanButtonClick', () => {
-            // Braze displays button id from 1, but internal representation is numbered from 0
-            // This ensures that the Button ID in Braze and Ophan will be the same
-            const externalButtonId = internalButtonId + 1;
-            submitComponentEvent({
-                component: {
-                    componentType: 'RETENTION_ENGAGEMENT_BANNER',
-                    id: ophanComponentId,
-                },
-                action: 'CLICK',
-                value: externalButtonId.toString(10),
-            });
-        });
-
-        catchAndLogErrors('brazeButtonClick', () => {
-            logButtonClickWithBraze(internalButtonId);
-        });
+        logToBrazeAndOphan(internalButtonId);
     };
 
     if (!showBanner || !header || !body) {

--- a/src/TheGuardianIn2020Banner/index.tsx
+++ b/src/TheGuardianIn2020Banner/index.tsx
@@ -26,26 +26,6 @@ const catchAndLogErrors = (description: string, fn: () => void): void => {
     }
 };
 
-const logToBrazeAndOphan = (internalButtonId: number): void => {
-    catchAndLogErrors('ophanButtonClick', () => {
-        // Braze displays button id from 1, but internal representation is numbered from 0
-        // This ensures that the Button ID in Braze and Ophan will be the same
-        const externalButtonId = internalButtonId + 1;
-        submitComponentEvent({
-            component: {
-                componentType: 'RETENTION_ENGAGEMENT_BANNER',
-                id: ophanComponentId,
-            },
-            action: 'CLICK',
-            value: externalButtonId.toString(10),
-        });
-    });
-
-    catchAndLogErrors('brazeButtonClick', () => {
-        logButtonClickWithBraze(internalButtonId);
-    });
-};
-
 export const COMPONENT_NAME = 'TheGuardianIn2020Banner';
 
 const urlObject = new URL(
@@ -70,6 +50,25 @@ export const TheGuardianIn2020Banner: React.FC<Props> = ({
 }: Props) => {
     const [showBanner, setShowBanner] = useState(true);
 
+    const logToBrazeAndOphan = (internalButtonId: number): void => {
+        catchAndLogErrors('ophanButtonClick', () => {
+            // Braze displays button id from 1, but internal representation is numbered from 0
+            // This ensures that the Button ID in Braze and Ophan will be the same
+            const externalButtonId = internalButtonId + 1;
+            submitComponentEvent({
+                component: {
+                    componentType: 'RETENTION_ENGAGEMENT_BANNER',
+                    id: ophanComponentId,
+                },
+                action: 'CLICK',
+                value: externalButtonId.toString(10),
+            });
+        });
+
+        catchAndLogErrors('brazeButtonClick', () => {
+            logButtonClickWithBraze(internalButtonId);
+        });
+    };
     const onClick = logToBrazeAndOphan;
 
     const onCloseClick = (

--- a/src/TheGuardianIn2020Banner/index.tsx
+++ b/src/TheGuardianIn2020Banner/index.tsx
@@ -50,6 +50,28 @@ export const TheGuardianIn2020Banner: React.FC<Props> = ({
 }: Props) => {
     const [showBanner, setShowBanner] = useState(true);
 
+    const onClick = (internalButtonId: number): void => {
+        setShowBanner(false);
+
+        catchAndLogErrors('ophanButtonClick', () => {
+            // Braze displays button id from 1, but internal representation is numbered from 0
+            // This ensures that the Button ID in Braze and Ophan will be the same
+            const externalButtonId = internalButtonId + 1;
+            submitComponentEvent({
+                component: {
+                    componentType: 'RETENTION_ENGAGEMENT_BANNER',
+                    id: ophanComponentId,
+                },
+                action: 'CLICK',
+                value: externalButtonId.toString(10),
+            });
+        });
+
+        catchAndLogErrors('brazeButtonClick', () => {
+            logButtonClickWithBraze(internalButtonId);
+        });
+    };
+
     const onCloseClick = (
         evt: React.MouseEvent<HTMLButtonElement, MouseEvent>,
         internalButtonId: number,
@@ -80,7 +102,6 @@ export const TheGuardianIn2020Banner: React.FC<Props> = ({
     if (!showBanner || !header || !body) {
         return null;
     }
-
     return (
         <div css={commonStyles.wrapper}>
             <div css={commonStyles.contentContainer}>
@@ -101,7 +122,11 @@ export const TheGuardianIn2020Banner: React.FC<Props> = ({
                             Read our look-back to see how Guardian journalism made a difference.
                         </strong>
                     </p>
-                    <LinkButton href={THE_GU_IN_2020_URL} css={commonStyles.primaryButton}>
+                    <LinkButton
+                        href={THE_GU_IN_2020_URL}
+                        css={commonStyles.primaryButton}
+                        onClick={() => onClick(0)}
+                    >
                         Take a look back
                     </LinkButton>
                 </div>


### PR DESCRIPTION
### Context:

We had previously not included click tracking for The Guardian In 2020 banner as we believed there were Braze tracking issues related to link clicks that redirect to a new page.

However, we have tested link clicks on fast and slow internet connections and found their tracking to be reliable in both cases (click tracking in Braze does not seem to rely on asynchronous requests after the click has occurred, but instead caches the click data locally and sends it to Braze on a subsequent page view).

### What this PR adds:

As our testing has found link click tracking to be reliable, I am adding it to the GuardianIn2020 Banner. Though this banner is no longer live, it is useful to have a banner component where link click tracking is in place as an example for future work, or as a basis for a future banner.

We will also be using equivalent click tracking in the Epic component.