### PR TITLE
Eslint should ignore the dist directory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,4 +34,5 @@ module.exports = {
             version: 'detect',
         },
     },
+    ignorePatterns: ['dist'],
 };


### PR DESCRIPTION
## What does this change?

When running `yarn eslint` ignore the `dist` folder.