### PR TITLE
Split Entry Points

### DIFF
--- a/logic-index.ts
+++ b/logic-index.ts
@@ -1,0 +1,1 @@
+export const add = (a: number, b: number): number => a + b;

--- a/logic/package.json
+++ b/logic/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/logic/index.js",
+  "module": "../dist/logic/index.esm.js",
+  "types": "../dist/index.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "logic/package.json"
   ],
   "scripts": {
     "watch": "rollup -cw",
+    "prebuild": "rm -rf dist",
     "build": "rollup -c",
     "postbuild": "tsc --project tsconfig.types.json",
     "test": "jest",


### PR DESCRIPTION
## What does this change?

This adds a second entry point for the package which we'll start using in a future PR for the business logic we're adding to this package. Currently the business logic contains a single placeholder function `add(a: number, b: number): number` as a proof of concept.

## How to test

On the platforms we can now create two separate bundles, allowing us to lazy load only the code we need.

For the business logic:

```js
import(
  /* webpackChunkName: "guardian-braze-components-logic" */ '@guardian/braze-components/logic'
)
  .then((module) => {
    const add = module.add;
    // Do something with add ...
  })
```

and for the React components:

```js
import(
  /* webpackChunkName: "guardian-braze-components" */ '@guardian/braze-components'
)
  .then((module) => {
    setBrazeComponent(() => module.BrazeMessage);
  })
```