### PR TITLE
Fix types exposed by package

### DIFF
--- a/logic/package.json
+++ b/logic/package.json
@@ -1,5 +1,5 @@
 {
   "main": "../dist/logic/index.js",
   "module": "../dist/logic/index.esm.js",
-  "types": "../dist/index.d.ts"
+  "types": "../dist/logic-index.d.ts"
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -9,5 +9,9 @@
     "allowJs": false,
     "emitDeclarationOnly": true
   },
-  "exclude": ["**/*.test.ts", "dist/**/*"]
+  "exclude": ["**/*.test.ts", "dist/**/*"],
+  "files": [
+    "./index.ts",
+    "./logic-index.ts"
+  ]
 }


### PR DESCRIPTION
## What does this change?

This ensures the correct TS types are available when importing /logic.