### PR TITLE
Don't rely on dependencies on the window object

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,15 +75,14 @@
   },
   "peerDependencies": {
     "@emotion/core": "10.0.x",
-    "preact-x": "npm:preact@10.3.1",
+    "emotion-theming": "^10.0.19",
     "react": "16.13.x"
   },
   "dependencies": {
     "@guardian/src-button": "2.7.1",
     "@guardian/src-foundations": "2.7.1",
     "@guardian/src-grid": "2.7.1",
-    "@guardian/src-icons": "2.7.1",
-    "emotion-theming": "^10.0.19"
+    "@guardian/src-icons": "2.7.1"
   },
   "np": {
     "branch": "main"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/braze-components",
-  "version": "0.0.19",
+  "version": "0.0.20-0",
   "description": "React components to render messages from Braze",
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/braze-components",
-  "version": "0.0.20-0",
+  "version": "0.0.20",
   "description": "React components to render messages from Braze",
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,16 +6,10 @@ import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import externalGlobals from 'rollup-plugin-external-globals';
 import pkg from './package.json';
 import visualizer from 'rollup-plugin-visualizer';
 
 const extensions = [...DEFAULT_EXTENSIONS, '.ts', '.tsx'];
-
-const globals = {
-    react: 'guardian.automat.preact',
-    '@emotion/core': 'guardian.automat.emotionCore',
-};
 
 const configs = [
     {
@@ -31,7 +25,6 @@ const configs = [
                 sourcemap: false,
             },
         ],
-        external: (id) => Object.keys(globals).some((key) => id == key),
         plugins: [
             peerDepsExternal(),
             resolve({ extensions: extensions }),
@@ -43,7 +36,6 @@ const configs = [
             }),
             terser(),
             filesize(),
-            externalGlobals(globals),
             // Note, visualizer is useful for *relative* sizes, but reports
             // pre-minification.
             visualizer({ gzipSize: true }),


### PR DESCRIPTION
## What does this change?

Instead of relying on dependencies from the window object, these are now resolved in a more conventional way and specified as peer dependencies.

Note that I've already created a release `v0.0.20` from this branch which has been developed against while getting the platforms ready for this change. We'll still need to bring these changes back into main so that future releases work. I'll merge this PR once `0.0.20` is being used on both platforms.

### Update 30/3:

I've merged `main` back into here, and resolved any conflicts. I deliberately didn't rebase because I want to retain the commits I did NPM package releases on (prerelease `0.0.20-0` and `0.0.20`).

Frontend is now using conventional dependencies instead of relying on the window (guardian/frontend#23610). DCR has a PR, not merged yet: guardian/dotcom-rendering#2752. Once those PRs are merged, we'll need this PR merged to main in order to do further NPM package releases off of main.