### PR TITLE
GU Preview to use URL fragment & reformat Epic story gu-preview output

### DIFF
--- a/.storybook/gu-preview/GuPreview.tsx
+++ b/.storybook/gu-preview/GuPreview.tsx
@@ -15,7 +15,7 @@ const IconButtonLabel = styled.div<{}>(({ theme }) => ({
 
 function constructPreviewUrl() {
     let baseUrl =
-        'https://preview.gutools.co.uk/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey?';
+        'https://preview.gutools.co.uk/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey#';
 
     const theKnobs = knobsData.get();
 

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -116,6 +116,23 @@ const buildProps = (data: DataFromKnobs): EpicProps => {
     };
 };
 
+const guPreviewOutput = (data: DataFromKnobs) => {
+    return Object.assign(
+        {},
+        {
+            heading: data.heading,
+            highlightedText: data.highlightedText,
+            buttonText: data.buttonText,
+            buttonUrl: data.buttonUrl,
+            componentName: data.componentName,
+            slotName: data.slotName,
+        },
+        ...data.paragraphs.map((p, i) => {
+            return { [`paragraph${i}`]: p };
+        }),
+    );
+};
+
 export const defaultStory = (): ReactElement => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const slotName = text('slotName', 'EndOfArticle');
@@ -138,7 +155,7 @@ export const defaultStory = (): ReactElement => {
         }
     }
 
-    const epicProps = buildProps({
+    const knobs = {
         heading,
         highlightedText,
         buttonText,
@@ -146,10 +163,12 @@ export const defaultStory = (): ReactElement => {
         paragraphs: paragraphs.filter((p) => p != ''),
         slotName,
         componentName,
-    });
+    };
+
+    const epicProps = buildProps(knobs);
 
     // This is to make the data available to the guPreview add-on:
-    knobsData.set(epicProps);
+    knobsData.set(guPreviewOutput(knobs));
 
     return (
         <StorybookWrapper>


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

1. Moves from a query string to a URL fragment (i.e. `#force-braze-message={ ... }`)

2. Fixes the data outputted from the Epic story:

The JSON-encoded data in the GU Preview addon URL for the Epic story did not match the format of data expected by the platform when using `force-braze-message`.

The platform expects e.g:

```js
{
  heading: data.heading,
  highlightedText: data.highlightedText,
  buttonText: data.buttonText,
  buttonUrl: data.buttonUrl,
  componentName: data.componentName,
  slotName: data.slotName,
  paragraph1: "Lorem ipsum...",
  paragraph2: "Dolor sit amet..."
}
```
While we were previously providing:

```js
{
  cta: { 
    text: data.buttonText, baseUrl: data.buttonUrl 
  },
  heading: data.heading,
  highlightedText: data.highlightedText,
  paragraphs: [ "Lorem ipsum...", "Dolor sit amet..."
}
```

We now output the data expected by the platform, allowing us to use a URL fragment to force an Epic to show.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Test the output on a branch of Frontend/DCR using a URL-fragment-based `force-braze-message`, as below:
![image](https://user-images.githubusercontent.com/34686302/113303392-f3842300-92f8-11eb-9e20-d2244b3c2334.png)
