### PR TITLE
Add error messages when messages expire or cannot be added to full queue

### DIFF
--- a/src/logic/BrazeMessages.test.ts
+++ b/src/logic/BrazeMessages.test.ts
@@ -122,10 +122,14 @@ describe('BrazeMessages', () => {
 
             it('returns a cached message if one is available', async () => {
                 const cachedMessage = buildMessage(JSON.parse(message1Json));
-                LocalMessageCache.push('EndOfArticle', {
-                    message: cachedMessage,
-                    id: '1',
-                });
+                LocalMessageCache.push(
+                    'EndOfArticle',
+                    {
+                        message: cachedMessage,
+                        id: '1',
+                    },
+                    (e) => console.log(e),
+                );
                 const freshMessage = buildMessage(JSON.parse(message2Json));
                 const fakeAppBoy = new FakeAppBoy();
                 const brazeMessages = new BrazeMessages(
@@ -142,10 +146,14 @@ describe('BrazeMessages', () => {
 
             it('logging an impression results in the message being removed from the cache', async () => {
                 const cachedMessage = buildMessage(JSON.parse(message1Json));
-                LocalMessageCache.push('EndOfArticle', {
-                    message: cachedMessage,
-                    id: '1',
-                });
+                LocalMessageCache.push(
+                    'EndOfArticle',
+                    {
+                        message: cachedMessage,
+                        id: '1',
+                    },
+                    (e) => console.log(e),
+                );
                 const freshMessage = buildMessage(JSON.parse(message2Json));
                 const fakeAppBoy = new FakeAppBoy();
                 const brazeMessages = new BrazeMessages(
@@ -164,10 +172,14 @@ describe('BrazeMessages', () => {
 
             it('returns the same cached message multiple times if an impression is not logged', async () => {
                 const cachedMessage = buildMessage(JSON.parse(message1Json));
-                LocalMessageCache.push('EndOfArticle', {
-                    message: cachedMessage,
-                    id: '1',
-                });
+                LocalMessageCache.push(
+                    'EndOfArticle',
+                    {
+                        message: cachedMessage,
+                        id: '1',
+                    },
+                    (e) => console.log(e),
+                );
                 const freshMessage = buildMessage(JSON.parse(message2Json));
                 const fakeAppBoy = new FakeAppBoy();
                 const brazeMessages = new BrazeMessages(

--- a/src/logic/BrazeMessages.tsx
+++ b/src/logic/BrazeMessages.tsx
@@ -5,7 +5,7 @@ import { MessageCache } from './LocalMessageCache';
 import type { SlotName } from './types';
 
 type Extras = Record<string, string>;
-type ErrorHandler = (error: Error, identifier: string) => void;
+export type ErrorHandler = (error: Error, identifier: string) => void;
 
 interface BrazeMessagesInterface {
     getMessageForBanner: () => Promise<BrazeMessage>;
@@ -41,6 +41,7 @@ class BrazeMessage {
         this.slotName = slotName;
         this.cache = cache;
         this.errorHandler = errorHandler;
+        this.cache.errorHandler = errorHandler;
     }
 
     logImpression(): void {

--- a/src/logic/BrazeMessages.tsx
+++ b/src/logic/BrazeMessages.tsx
@@ -41,7 +41,6 @@ class BrazeMessage {
         this.slotName = slotName;
         this.cache = cache;
         this.errorHandler = errorHandler;
-        this.cache.errorHandler = errorHandler;
     }
 
     logImpression(): void {
@@ -51,7 +50,7 @@ class BrazeMessage {
             this.errorHandler(error, 'BrazeMessage.logImpression');
         }
 
-        this.cache.remove(this.slotName, this.id);
+        this.cache.remove(this.slotName, this.id, this.errorHandler);
     }
 
     logButtonClick(internalButtonId: number): void {
@@ -105,10 +104,14 @@ class BrazeMessages implements BrazeMessagesInterface {
                 const { extras } = message;
 
                 if (extras && extras.slotName && extras.slotName === targetSlotName) {
-                    this.cache.push(targetSlotName, {
-                        message,
-                        id: generateId(),
-                    });
+                    this.cache.push(
+                        targetSlotName,
+                        {
+                            message,
+                            id: generateId(),
+                        },
+                        this.errorHandler,
+                    );
 
                     resolve(message);
                 }
@@ -120,7 +123,7 @@ class BrazeMessages implements BrazeMessagesInterface {
 
     getMessageForBanner(): Promise<BrazeMessage> {
         // If there's already a message in the cache, return it
-        const messageFromCache = this.cache.peek('Banner', this.appboy);
+        const messageFromCache = this.cache.peek('Banner', this.appboy, this.errorHandler);
 
         if (messageFromCache) {
             return Promise.resolve(
@@ -138,7 +141,7 @@ class BrazeMessages implements BrazeMessagesInterface {
         // Otherwise we'll wait for a fresh message to arrive, returning the
         // data from the cache (where it will have already been added)
         return this.freshBannerMessage.then(() => {
-            const freshMessageFromCache = this.cache.peek('Banner', this.appboy);
+            const freshMessageFromCache = this.cache.peek('Banner', this.appboy, this.errorHandler);
 
             if (freshMessageFromCache) {
                 return new BrazeMessage(
@@ -158,7 +161,7 @@ class BrazeMessages implements BrazeMessagesInterface {
 
     getMessageForEndOfArticle(): Promise<BrazeMessage> {
         // If there's already a message in the cache, return it
-        const messageFromCache = this.cache.peek('EndOfArticle', this.appboy);
+        const messageFromCache = this.cache.peek('EndOfArticle', this.appboy, this.errorHandler);
 
         if (messageFromCache) {
             return Promise.resolve(
@@ -176,7 +179,11 @@ class BrazeMessages implements BrazeMessagesInterface {
         // Otherwise we'll wait for a fresh message to arrive, returning the
         // data from the cache (where it will have already been added)
         return this.freshEndOfArticleMessage.then(() => {
-            const freshMessageFromCache = this.cache.peek('EndOfArticle', this.appboy);
+            const freshMessageFromCache = this.cache.peek(
+                'EndOfArticle',
+                this.appboy,
+                this.errorHandler,
+            );
 
             if (freshMessageFromCache) {
                 return new BrazeMessage(

--- a/src/logic/LocalMessageCache.test.ts
+++ b/src/logic/LocalMessageCache.test.ts
@@ -228,6 +228,34 @@ describe('LocalMessageCache', () => {
             expect(newQueue.map(({ message: m }) => m.message)).toEqual([message1, message2]);
         });
 
+        it('reports when a message cannot be added to a full queue', () => {
+            const message1 = JSON.parse(message1Json);
+            const errorHandler = jest.fn();
+            LocalMessageCache.errorHandler = errorHandler;
+            LocalMessageCache.push('EndOfArticle', {
+                message: message1,
+                id: '1',
+            });
+
+            const message2 = JSON.parse(message2Json);
+            LocalMessageCache.push('EndOfArticle', {
+                message: message2,
+                id: '2',
+            });
+
+            const message3 = JSON.parse(message3Json);
+            LocalMessageCache.push('EndOfArticle', {
+                message: message3,
+                id: '3',
+            });
+
+            expect(errorHandler).toHaveBeenCalledTimes(1);
+            expect(errorHandler).toHaveBeenCalledWith(
+                new Error('Failed to add message to queue - queue full'),
+                'LocalMessageCache',
+            );
+        });
+
         it('returns false when the push is unsuccessful', () => {
             const message1 = JSON.parse(message1Json);
             const message2 = JSON.parse(message2Json);

--- a/src/logic/LocalMessageCache.test.ts
+++ b/src/logic/LocalMessageCache.test.ts
@@ -11,7 +11,8 @@ type Message = appboy.InAppMessage;
 
 beforeEach(() => {
     storage.local.clear();
-    LocalMessageCache.errorHandler = undefined;
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    LocalMessageCache.errorHandler = () => {};
 });
 
 const getQueueSizeFor = (slotName: SlotName): number => {

--- a/src/logic/LocalMessageCache.test.ts
+++ b/src/logic/LocalMessageCache.test.ts
@@ -113,6 +113,26 @@ describe('LocalMessageCache', () => {
             expect(queueSize).toEqual(1);
         });
 
+        it('calls errorHandler when there are expired messages', () => {
+            const errorHandler = jest.fn();
+            LocalMessageCache.errorHandler = errorHandler;
+            const message1 = JSON.parse(message1Json);
+            const message2 = JSON.parse(message2Json);
+            const queue = [
+                buildExpiredMessage(message1, '1'),
+                buildUnexpiredMessage(message2, '2'),
+            ];
+            setQueue('EndOfArticle', queue);
+
+            LocalMessageCache.peek('EndOfArticle', appboy);
+
+            expect(errorHandler).toHaveBeenCalledTimes(1);
+            expect(errorHandler).toHaveBeenCalledWith(
+                new Error('Removed 1 expired message from queue'),
+                'LocalMessageCache',
+            );
+        });
+
         it('filters invalid items from the queue', () => {
             const nonsenseMessage = ('nonsense' as unknown) as CachedMessage;
             const anotherNonsenseMessage = ({

--- a/src/logic/LocalMessageCache.test.ts
+++ b/src/logic/LocalMessageCache.test.ts
@@ -11,6 +11,7 @@ type Message = appboy.InAppMessage;
 
 beforeEach(() => {
     storage.local.clear();
+    LocalMessageCache.errorHandler = undefined;
 });
 
 const getQueueSizeFor = (slotName: SlotName): number => {

--- a/src/logic/LocalMessageCache.tsx
+++ b/src/logic/LocalMessageCache.tsx
@@ -86,13 +86,13 @@ const getQueue = (slotName: SlotName, errorHandler?: ErrorHandler): CachedMessag
     const unexpiredQueue = validQueue.filter((i) => hasNotExpired(i));
 
     if (queue.length !== unexpiredQueue.length) {
-        const expiredMessages = queue.length - unexpiredQueue.length;
+        const expiredMessageCount = queue.length - unexpiredQueue.length;
 
         if (errorHandler) {
             errorHandler(
                 Error(
-                    `Removed ${expiredMessages} expired message${
-                        expiredMessages === 1 ? '' : 's'
+                    `Removed ${expiredMessageCount} expired message${
+                        expiredMessageCount === 1 ? '' : 's'
                     } from queue`,
                 ),
                 'LocalMessageCache',

--- a/src/logic/LocalMessageCache.tsx
+++ b/src/logic/LocalMessageCache.tsx
@@ -117,7 +117,7 @@ class LocalMessageCache {
     static errorHandler: ErrorHandler;
 
     static peek(slotName: SlotName, appboyInstance: typeof appboy): MessageWithId | undefined {
-        const queue = getQueue(slotName);
+        const queue = getQueue(slotName, this.errorHandler);
         const topItem = queue[0];
 
         if (topItem) {
@@ -130,7 +130,7 @@ class LocalMessageCache {
     }
 
     static remove(slotName: SlotName, id: string): boolean {
-        const queue = getQueue(slotName, this.errorHandler ? this.errorHandler : undefined);
+        const queue = getQueue(slotName, this.errorHandler);
         const idx = queue.findIndex((i) => i.message.id === id);
 
         if (idx >= 0) {
@@ -146,7 +146,7 @@ class LocalMessageCache {
     }
 
     static push(slotName: SlotName, message: MessageWithId): boolean {
-        const queue = getQueue(slotName);
+        const queue = getQueue(slotName, this.errorHandler);
 
         if (queue.length < MAX_QUEUE_SIZE) {
             const expires = Date.now() + millisecondsBeforeExpiry;

--- a/src/logic/LocalMessageCache.tsx
+++ b/src/logic/LocalMessageCache.tsx
@@ -163,7 +163,7 @@ class LocalMessageCache {
         }
         if (this.errorHandler) {
             this.errorHandler(
-                Error('Failed to add message to queue - queue full'),
+                new Error('Failed to add message to queue - queue full'),
                 'LocalMessageCache',
             );
         }

--- a/src/logic/LocalMessageCache.tsx
+++ b/src/logic/LocalMessageCache.tsx
@@ -80,7 +80,7 @@ const isValid = (m: CachedMessage): boolean => {
     );
 };
 
-const getQueue = (slotName: SlotName, errorHandler?: ErrorHandler): CachedMessage[] => {
+const getQueue = (slotName: SlotName, errorHandler: ErrorHandler): CachedMessage[] => {
     const queue = readQueue(slotName);
     const validQueue = queue.filter((i) => isValid(i));
     const unexpiredQueue = validQueue.filter((i) => hasNotExpired(i));
@@ -88,16 +88,14 @@ const getQueue = (slotName: SlotName, errorHandler?: ErrorHandler): CachedMessag
     if (queue.length !== unexpiredQueue.length) {
         const expiredMessageCount = queue.length - unexpiredQueue.length;
 
-        if (errorHandler) {
-            errorHandler(
-                Error(
-                    `Removed ${expiredMessageCount} expired message${
-                        expiredMessageCount === 1 ? '' : 's'
-                    } from queue`,
-                ),
-                'LocalMessageCache',
-            );
-        }
+        errorHandler(
+            Error(
+                `Removed ${expiredMessageCount} expired message${
+                    expiredMessageCount === 1 ? '' : 's'
+                } from queue`,
+            ),
+            'LocalMessageCache',
+        );
 
         setQueue(slotName, unexpiredQueue);
     }
@@ -106,18 +104,23 @@ const getQueue = (slotName: SlotName, errorHandler?: ErrorHandler): CachedMessag
 };
 
 interface MessageCache {
-    peek: (slotName: SlotName, appboyInstance: typeof appboy) => MessageWithId | undefined;
-    remove: (slotName: SlotName, id: string) => boolean;
-    push: (slotName: SlotName, message: MessageWithId) => boolean;
+    peek: (
+        slotName: SlotName,
+        appboyInstance: typeof appboy,
+        errorHandler: ErrorHandler,
+    ) => MessageWithId | undefined;
+    remove: (slotName: SlotName, id: string, errorHandler: ErrorHandler) => boolean;
+    push: (slotName: SlotName, message: MessageWithId, errorHandler: ErrorHandler) => boolean;
     clear: () => void;
-    errorHandler: ErrorHandler;
 }
 
 class LocalMessageCache {
-    static errorHandler: ErrorHandler;
-
-    static peek(slotName: SlotName, appboyInstance: typeof appboy): MessageWithId | undefined {
-        const queue = getQueue(slotName, this.errorHandler);
+    static peek(
+        slotName: SlotName,
+        appboyInstance: typeof appboy,
+        errorHandler: ErrorHandler,
+    ): MessageWithId | undefined {
+        const queue = getQueue(slotName, errorHandler);
         const topItem = queue[0];
 
         if (topItem) {
@@ -129,8 +132,8 @@ class LocalMessageCache {
         return;
     }
 
-    static remove(slotName: SlotName, id: string): boolean {
-        const queue = getQueue(slotName, this.errorHandler);
+    static remove(slotName: SlotName, id: string, errorHandler: ErrorHandler): boolean {
+        const queue = getQueue(slotName, errorHandler);
         const idx = queue.findIndex((i) => i.message.id === id);
 
         if (idx >= 0) {
@@ -145,8 +148,8 @@ class LocalMessageCache {
         return false;
     }
 
-    static push(slotName: SlotName, message: MessageWithId): boolean {
-        const queue = getQueue(slotName, this.errorHandler);
+    static push(slotName: SlotName, message: MessageWithId, errorHandler: ErrorHandler): boolean {
+        const queue = getQueue(slotName, errorHandler);
 
         if (queue.length < MAX_QUEUE_SIZE) {
             const expires = Date.now() + millisecondsBeforeExpiry;
@@ -161,12 +164,8 @@ class LocalMessageCache {
             setQueue(slotName, queue);
             return true;
         }
-        if (this.errorHandler) {
-            this.errorHandler(
-                new Error('Failed to add message to queue - queue full'),
-                'LocalMessageCache',
-            );
-        }
+        errorHandler(new Error('Failed to add message to queue - queue full'), 'LocalMessageCache');
+
         return false;
     }
 
@@ -192,8 +191,6 @@ const inMemoryQueue: Record<SlotName, InMemoryCachedMessage[]> = {
 // Until we're ready to turn caching on we can use this as a swap in replacement
 // for LocalMessageCache.
 class InMemoryCache {
-    static errorHandler: ErrorHandler;
-
     static peek(slotName: SlotName): MessageWithId | undefined {
         const unexpiredMessages = inMemoryQueue[slotName].filter((i) => hasNotExpired(i));
         return unexpiredMessages[0]?.message;


### PR DESCRIPTION
## What does this change?

[Related trello card.](https://trello.com/c/9ss9sL1e/1114-actually-start-using-message-caching-on-dcr-and-frontend)

Log error messages from `LocalMessageCache` when messages expire or cannot be added to a full queue. `errorHandler` is provided by the platform (Frontend / DCR) - currently this will log to Sentry on both platforms.

The `errorHandler` must already provided to `BrazeMessages` by the platform (this was already the case).