### PR TITLE
Remove unused variable in rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,11 +13,6 @@ import { resolve as resolvePath } from 'path';
 
 const extensions = [...DEFAULT_EXTENSIONS, '.ts', '.tsx'];
 
-const globals = {
-    react: 'guardian.automat.preact',
-    '@emotion/core': 'guardian.automat.emotionCore',
-};
-
 const commonConfig = {
     plugins: [
         peerDepsExternal(),


### PR DESCRIPTION
## What does this change?

We moved away from relying on dependencies via the window in #121 but deleting this `const globals` was missed.

## How to test

`yarn build` runs successfully.