### PR TITLE
Add ophanComponentId knob to Braze epic story

### DIFF
--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -133,6 +133,16 @@ const guPreviewOutput = (data: DataFromKnobs) => {
     );
 };
 
+const componentMappings = {
+    Epic: Epic,
+};
+
+const NullComponent = () => null;
+
+const getComponentfromName = (name: string) => {
+    return componentMappings[name] || NullComponent;
+};
+
 export const defaultStory = (): ReactElement => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const slotName = text('slotName', 'EndOfArticle');
@@ -170,9 +180,11 @@ export const defaultStory = (): ReactElement => {
     // This is to make the data available to the guPreview add-on:
     knobsData.set(guPreviewOutput(knobs));
 
+    const Component = getComponentfromName(componentName);
+
     return (
         <StorybookWrapper>
-            <Epic {...epicProps}></Epic>
+            <Component {...epicProps} />
         </StorybookWrapper>
     );
 };

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -68,6 +68,7 @@ type DataFromKnobs = {
     paragraphs: Array<string>;
     slotName?: string;
     componentName?: string;
+    ophanComponentId: string;
 };
 
 const Epic: React.FC<EpicProps> = (props) => {
@@ -144,10 +145,9 @@ const getComponentfromName = (name: string) => {
 };
 
 export const defaultStory = (): ReactElement => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const slotName = text('slotName', 'EndOfArticle');
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const componentName = text('componentName', 'Epic');
+    const ophanComponentId = text('ophanComponentId', 'example_ophan_component_id');
     const heading = text('heading', defaultContent.heading);
     const highlightedText = text('highlightedText', defaultContent.highlightedText);
     const buttonText = text('buttonText', defaultContent.buttonText);
@@ -173,6 +173,7 @@ export const defaultStory = (): ReactElement => {
         paragraphs: paragraphs.filter((p) => p != ''),
         slotName,
         componentName,
+        ophanComponentId,
     };
 
     const epicProps = buildProps(knobs);

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -181,6 +181,21 @@ export const defaultStory = (): ReactElement => {
     // This is to make the data available to the guPreview add-on:
     knobsData.set(guPreviewOutput(knobs));
 
+    // It is unfortunate that here we're duplicating the checks that we do
+    // on-platform before rendering the Braze epic. This should be addressed
+    // properly, but in the meantime I'm keen to have Storybook reflect the
+    // platform behaviour so this doesn't cause confusion for marketing.
+    if (
+        !heading ||
+        !highlightedText ||
+        !buttonText ||
+        !buttonUrl ||
+        !ophanComponentId ||
+        paragraphs.length < 1
+    ) {
+        return null;
+    }
+
     const Component = getComponentfromName(componentName);
 
     return (


### PR DESCRIPTION
## What does this change?

We realised that we need marketing to configure an `ophanComponentId` in the key value pairs sent from Braze which we'll pass with the Ophan view event. It's not passed as a prop to the component but is used on platform. Because marketing use Storybook as the staging ground for key/value pairs and then copy over to Braze, include it in the story:

![Screenshot 2021-04-16 at 17 24 03](https://user-images.githubusercontent.com/379839/115054956-c5960580-9ed8-11eb-9b0a-5f2a6e11a38e.png)

## How to test

`yarn storybook`

## Notes

In working on this we realised that the behaviour of Storybook didn't match the production behaviour on DCR where we [validate that certain props have been provided](https://github.com/guardian/dotcom-rendering/blob/acb093890c93ce6c314106bbe45e634e0be20103/src/web/lib/braze/parseBrazeEpicParams.ts#L45) (via Braze key value pairs) and render nothing if they aren't there. I've added that behaviour to Storybook but it's unfortunate that here we're duplicating the checks that we do on DCR. This should be addressed properly, but in the meantime I'm keen to have Storybook reflect the platform behaviour so this doesn't cause confusion for marketing. This isn’t an issue with the banner components as the component itself does these checks. Here we’re using the support-dotcom-components epic and aren’t in control of the prop validation. Possibly an argument for having our own epic component.
