### PR TITLE
Update prop check to reflect DCR

### DIFF
--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -186,14 +186,7 @@ export const defaultStory = (): ReactElement => {
     // on-platform before rendering the Braze epic. This should be addressed
     // properly, but in the meantime I'm keen to have Storybook reflect the
     // platform behaviour so this doesn't cause confusion for marketing.
-    if (
-        !heading ||
-        !highlightedText ||
-        !buttonText ||
-        !buttonUrl ||
-        !ophanComponentId ||
-        paragraphs.length < 1
-    ) {
+    if (!buttonText || !buttonUrl || !ophanComponentId || paragraphs.length < 1) {
         return null;
     }
 


### PR DESCRIPTION
## What does this change?

Align with the changes in guardian/dotcom-rendering#2927 and relax the prop validation we do (`heading` and `highlightedText` are not required). This ensures that the behaviour marketing seeing when previewing with Storybook will match the way the platform behaves.

Having to update this in two places is clearly not ideal. I think if we keep using this epic component we should stop borrowing from support-dotcom-components and bring the `Epic` component into this repo. Otherwise marketing may decide not to use this format for future end-of-article messages. Either way we'll move away from the support-dotcom-components epic component.

## How to test

`yarn storybook`

## Images

Epic without `heading` or `highlightedText`:

<img width="1552" alt="Screenshot 2021-04-27 at 17 04 34" src="https://user-images.githubusercontent.com/379839/116275299-68713e00-a77b-11eb-832a-3762b160581c.png">
