### PR TITLE
Add debug tests to launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "name": "vscode-jest-tests",
+            "request": "launch",
+            "args": [
+                "--runInBand"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        }
+    ]
+}


### PR DESCRIPTION
## What does this change?
Adds VSCode launch config for debugging tests

## How to test
Checkout with VSCode. Add a breakpoint to any test file. Click the Run and Debug button on the left hand side. Then choose vscode-jest-tests and click the run button next to that dropdown. This should run the tests and break at your breakpoint to allow debugging.

## How can we measure success?
You can debug tests helping you fix tests faster.

## Have we considered potential risks?
We might spend too long debugging tests and go insane.

## Images
![Screenshot 2021-05-10 at 13 08 24](https://user-images.githubusercontent.com/3285072/117656937-dd3b7380-b190-11eb-96e5-00a77cac9790.png)
