### PR TITLE
Use the v2 ContributionsEpic component

### DIFF
--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -2,9 +2,10 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { knobsData } from '../utils/knobsData';
-import * as emotionCore from '@emotion/react';
+import * as emotionReact from '@emotion/react';
+import * as emotionReactJsxRuntime from '@emotion/react/jsx-runtime';
 
-const css = emotionCore.css;
+const css = emotionReact.css;
 
 export default {
     component: 'Epic',
@@ -15,7 +16,7 @@ export default {
     },
 };
 
-const componentUrl = `https://contributions.guardianapis.com/modules/v1/epics/ContributionsEpic.js`;
+const componentUrl = `https://contributions.guardianapis.com/modules/v2/epics/ContributionsEpic.js`;
 const epicWrapper = css`
     box-sizing: border-box;
     width: 100%;
@@ -75,7 +76,9 @@ const Epic: React.FC<EpicProps> = (props) => {
         window.guardian = {};
         window.guardian.automat = {
             preact: React,
-            emotionCore,
+            react: React,
+            emotionReact,
+            emotionReactJsxRuntime,
         };
         import(/*webpackIgnore: true*/ componentUrl)
             .then((epicModule: { ContributionsEpic: React.FC<EpicProps> }) => {


### PR DESCRIPTION
## What does this change?

Updates the epic component loaded from support-dotcom-components in our epic story. This reflects what we're now doing in prod, as of guardian/dotcom-rendering#2994.
 
## How to test

`yarn storybook`

The epic story will now load the v2 component, you can see this in the network inspector.

## Have we considered potential risks?

As time goes on, "borrowing" the epic component from source-dotcom-components feels like less of a good idea. It's inconsistent with our other Braze messages and feels more fragile. I'd be keen to bring the epic component fully into this project in future.

## Images

![Screenshot 2021-05-21 at 16 11 31](https://user-images.githubusercontent.com/379839/119159618-53708d80-ba4f-11eb-9a87-29154e2e05f6.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
