### PR TITLE
Integrate with GuTools login and image signing service

### DIFF
--- a/.storybook/grid/gridStyles.ts
+++ b/.storybook/grid/gridStyles.ts
@@ -1,108 +1,94 @@
-import { css } from '@emotion/core';
+import React from 'react';
 
-const barHeight = "48px"
+const barHeight = '48px';
 
-export const styles = {
-    modal: css`
-        position: absolute;
-        top: ${barHeight};
-        left: 0;
-        width: 100%;
-        height: calc(100% - ${barHeight});
-    `,
-    iframe: css`
-        width: 100%;
-        height: 100%;
-    `,
-    buttonRow: css`
-        display: flex;
-        border-bottom: 1px solid rgba(0,0,0,.1);
-        margin: 0 15px;
-        padding: 8px 0;
-        justify-content: space-between;
-    `,
-    activeButton: css`
-        border: 0;
-        cursor: pointer;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        transition: all 150ms ease-out;
-        transform: translate3d(0,0,0);
-        vertical-align: top;
-        white-space: nowrap;
-        margin: 0;
-        font-size: 12px;
-        font-weight: 700;
-        line-height: 1;
-        background: #fafafa;
-        color: #333333;
-        box-shadow: rgba(0,0,0,.1) 0 0 0 1px inset;
-        border-radius: 4px;
-        padding: 10px 16px;
-        display: inline;
-        overflow: visible;
-    `,
-    resultRow: css`
-        display: flex;
-        border-bottom: 1px solid rgba(0,0,0,.1);
-        margin: 0 15px;
-        padding: 8px 0;
-    `,
-    resultKey: css`
-        min-width: 100px;
-        font-weight: 700;
-        margin-right: 15px;
-        display: flex;
-        justify-content: flex-start;
-        align-items: center;
-        line-height: 16px;
-        box-sizing: border-box;
-    `,
-    resultValue: css`
-        appearance: none;
-        border: 0 none;
-        box-sizing: inherit;
-        display: block;
-        margin: 0;
-        background: #FFFFFF;
-        padding: 6px 10px;
-        font-size: 13px;
-        position: relative;
-        transition: all 200ms ease-out;
-        color: #333333;
-        box-shadow: rgba(0,0,0,.1) 0 0 0 1px inset;
-        border-radius: 4px;
-        line-height: 20px;
-        flex: 1;
-        text-align: left;
-        overflow: visible;
-        height: 52px;
-    `,
-    inactiveButton: css`
-        border: 0;
-        cursor: no-drop;
-        position: relative;
-        text-align: center;
-        text-decoration: none;
-        transition: all 150ms ease-out;
-        transform: translate3d(0,0,0);
-        vertical-align: top;
-        white-space: nowrap;
-        margin: 0;
-        font-size: 12px;
-        font-weight: 700;
-        line-height: 1;
-        background: #dddddd;
-        color: #aaaaaa;
-        box-shadow: rgba(0,0,0,.1) 0 0 0 1px inset;
-        border-radius: 4px;
-        border-bottom-style: none;
-        padding: 10px 16px;
-        display: inline;
-        overflow: visible;
-        &:focus {
-            outline: none !important;
-        }
-    `,
+export const nonEmotionStyles: Record<string, React.CSSProperties> = {
+    modal: {
+        position: 'absolute',
+        top: barHeight,
+        left: 0,
+        width: '100%',
+        height: `calc(100% - ${barHeight}`,
+    },
+    iframe: {
+        width: '100%',
+        height: '100%',
+    },
+    buttonRow: {
+        display: 'flex',
+        borderBottom: '1px solid rgba(0,0,0,.1)',
+        margin: '0 15px',
+        padding: '8px 0',
+        justifyContent: 'space-between',
+    },
+    activeButton: {
+        border: '0',
+        cursor: 'pointer',
+        position: 'relative',
+        textAlign: 'center',
+        textDecoration: 'none',
+        transition: 'all 150ms ease-out',
+        transform: 'translate3d(0,0,0)',
+        verticalAlign: 'top',
+        whiteSpace: 'nowrap',
+        margin: '0',
+        fontSize: '12px',
+        fontWeight: 'bold',
+        lineHeight: '1',
+        background: '#fafafa',
+        color: '#333333',
+        boxShadow: 'rgba(0,0,0,.1) 0 0 0 1px inset',
+        borderRadius: '4px',
+        padding: '10px 16px',
+        display: 'inline',
+        overflow: 'visible',
+    },
+    inactiveButton: {
+        border: '0',
+        cursor: 'no-drop',
+        position: 'relative',
+        textAlign: 'center',
+        textDecoration: 'none',
+        transition: 'all 150ms ease-out',
+        transform: 'translate3d(0,0,0)',
+        verticalAlign: 'top',
+        whiteSpace: 'nowrap',
+        margin: '0',
+        fontSize: '12px',
+        fontWeight: 'bold',
+        lineHeight: '1',
+        background: '#dddddd',
+        color: '#aaaaaa',
+        boxShadow: 'rgba(0,0,0,.1) 0 0 0 1px inset',
+        borderRadius: '4px',
+        padding: '10px 16px',
+        display: 'inline',
+        overflow: 'visible',
+    },
+    resultRow: {
+        display: 'flex',
+        borderBottom: '1px solid rgba(0,0,0,.1)',
+        margin: '0 15px',
+        padding: '8px 0',
+    },
+    resultValue: {
+        appearance: 'none',
+        border: '0 none',
+        boxSizing: 'inherit',
+        display: 'block',
+        margin: '0',
+        background: '#ffffff',
+        padding: '6px 10px',
+        fontSize: '13px',
+        position: 'relative',
+        transition: 'all 200ms ease-out',
+        color: '#333333',
+        boxShadow: 'rgba(0, 0, 0, 0.1) 0 0 0 1px inset',
+        borderRadius: '4px',
+        lineHeight: '20px',
+        flex: '1',
+        textAlign: 'left',
+        overflow: 'visible',
+        height: '52px',
+    },
 };

--- a/.storybook/gu-auth/GuAuth.tsx
+++ b/.storybook/gu-auth/GuAuth.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect, useRef } from 'react';
+import dialogPolyfill from 'dialog-polyfill';
+import { css } from '@emotion/core';
+import { getLoginUrl } from '../utils';
+
+export const overlayStyles = css`
+    background-color: white;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.1);
+    height: 200px;
+    width: 300px;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    margin-left: -150px;
+    margin-top: -100px;
+    z-index: 999;
+
+    ::backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+`;
+
+export const GuAuth = () => {
+    const [hasCheckedLoggedInStatus, setCheckedLoggedInStatus] = useState<boolean>(false);
+    const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+    useEffect(() => {
+        if (dialogRef?.current) {
+            dialogPolyfill.registerDialog(dialogRef.current);
+        }
+    }, [dialogRef]);
+
+    useEffect(() => {
+        if (hasCheckedLoggedInStatus) {
+            dialogRef?.current?.close();
+        } else {
+            const alreadyOpen = dialogRef?.current?.open;
+
+            if (!alreadyOpen) {
+                dialogRef?.current?.showModal();
+
+                // Don't close the modal on escape
+                dialogRef?.current?.addEventListener('cancel', (e) => {
+                    e.preventDefault();
+                });
+            }
+        }
+    }, [hasCheckedLoggedInStatus]);
+
+    useEffect(() => {
+        const handleLogin = async () => {
+            const redirectToLogin = () => {
+                const currentLocation = window.location.href;
+
+                const loginUrl = `${getLoginUrl()}/login?returnUrl=${encodeURIComponent(
+                    currentLocation,
+                )}`;
+                window.location.href = loginUrl;
+            };
+
+            try {
+                const response = await fetch(`${getLoginUrl()}/whoami`, {
+                    credentials: 'include',
+                });
+
+                if (response.ok) {
+                    setTimeout(() => {
+                        setCheckedLoggedInStatus(true);
+                    }, 1000);
+                } else if (response.status === 401) {
+                    redirectToLogin();
+                } else {
+                    console.log(
+                        'Something went wrong talking to login service: ',
+                        response.statusText,
+                    );
+                }
+            } catch (e) {
+                // When the login service returns a 401 CORS headers are omitted, resulting in an
+                // error from the fetch /whoami call above and we end up in this catch block.
+                redirectToLogin();
+            }
+        };
+
+        handleLogin();
+    }, []);
+
+    return (
+        <dialog ref={dialogRef} css={overlayStyles}>
+            Authenticating...
+        </dialog>
+    );
+};

--- a/.storybook/gu-auth/register.js
+++ b/.storybook/gu-auth/register.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { addons, types } from '@storybook/addons';
+
+import { GuAuth } from './GuAuth';
+
+const GU_AUTH_ADDON_ID = 'guAuthAddon';
+const GU_AUTH_PANEL_ID = `${GU_AUTH_ADDON_ID}/panel`;
+
+if (process.env.STORYBOOK_DISABLE_AUTH !== 'true') {
+    addons.register(GU_AUTH_ADDON_ID, () => {
+        addons.add(GU_AUTH_PANEL_ID, {
+            title: 'Gu Auth',
+            type: types.TOOL,
+            render: () => <GuAuth />,
+            paramKey: 'guAuth', // This is the key under which parameters are expected in the addon config
+        });
+    });
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,13 +1,11 @@
 const path = require('path');
 
 module.exports = {
-    stories:
-        process.env.NODE_ENV === 'development'
-            ? ['../src/**/*.stories.tsx']
-            : ['../src/!(AppBanner)/*.stories.tsx'],
+    stories: ['../src/**/*.stories.tsx'],
     addons: [
         '@storybook/addon-knobs',
         '@storybook/addon-viewport',
+        './gu-auth/register.js',
         './gu-preview/register.js',
         './grid/register.js',
     ],

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -57,6 +57,6 @@ addParameters({
     },
     layout: 'fullscreen',
     grid: {
-        disabled: true,
+        disable: true,
     },
 });

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -1,12 +1,35 @@
-const matchesHostname = (hostname: string): boolean => window.location.hostname === hostname;
+const getEnvironment = () => {
+    const hostname = window.location.hostname;
+    switch (hostname) {
+        case 'braze-storybook.local.dev-gutools.co.uk': return 'LOCAL';
+        case 'braze-components.code.dev-gutools.co.uk': return 'CODE';
+        case 'braze-components.gutools.co.uk': return 'PROD';
+        default: throw `Could not determine environment for hostname ${hostname}`;
+    }
+}
 
-const isDevelopment = (): boolean => matchesHostname('braze-storybook.local.dev-gutools.co.uk');
-const isCode = (): boolean => matchesHostname('braze-components.code.dev-gutools.co.uk');
-const isProduction = (): boolean => matchesHostname('braze-components.gutools.co.uk');
+const getImageSigningUrl = () => {
+    switch (getEnvironment()) {
+        case 'LOCAL': return 'https://image-url-signing-service.local.dev-gutools.co.uk';
+        case 'CODE': return 'https://image-url-signing-service.code.dev-gutools.co.uk';
+        case 'PROD': return 'https://image-url-signing-service.gutools.co.uk';
+    }
+};
 
-const GRID_URL =
-    isDevelopment() || isCode()
-        ? 'https://media.test.dev-gutools.co.uk'
-        : 'https://media.gutools.co.uk';
+const getGridUrl = () => {
+    switch (getEnvironment()) {
+        case 'LOCAL': return 'https://media.test.dev-gutools.co.uk';
+        case 'CODE': return 'https://media.test.dev-gutools.co.uk';
+        case 'PROD': return 'https://media.gutools.co.uk';
+    }
+}
 
-export { GRID_URL };
+const getLoginUrl = () => {
+    switch (getEnvironment()) {
+        case 'LOCAL': return 'https://login.local.dev-gutools.co.uk';
+        case 'CODE': return 'https://login.code.dev-gutools.co.uk';
+        case 'PROD': return 'https://login.gutools.co.uk';
+    }
+}
+
+export { getGridUrl, getImageSigningUrl, getLoginUrl };

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
   "dependencies": {
     "@guardian/src-button": "3.3.0",
     "@guardian/src-foundations": "3.3.0",
-    "@guardian/src-icons": "3.3.0"
+    "@guardian/src-icons": "3.3.0",
+    "dialog-polyfill": "^0.5.4"
   },
   "np": {
     "branch": "main"

--- a/src/AppBanner/index.stories.tsx
+++ b/src/AppBanner/index.stories.tsx
@@ -14,7 +14,7 @@ export default {
             escapeHTML: false, // Block HTML escaping, preventing double-escaping of imgUrl special characters in Storybook
         },
         grid: {
-            disabled: false,
+            disable: false,
         },
     },
 };
@@ -29,7 +29,7 @@ export const defaultStory = (): ReactElement => {
     );
     const componentName = text('componentName', 'AppBanner');
     const imageUrl = grid(
-        'https://i.guim.co.uk/img/media/de6813b4dd9b9805a2d14dd6af14ae2b48e2e19e/0_0_930_520/930.png?width=930&quality=60&s=a7d81978655765847246c8d4d0cd0e7f',
+        'https://i.guim.co.uk/img/media/de6813b4dd9b9805a2d14dd6af14ae2b48e2e19e/0_0_930_520/master/930.png?quality=45&width=930&s=0beb53509265d32e3d201aa3981323bb',
     );
     const cta = text('cta', 'Search for "Guardian live news"');
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,3 +1,1 @@
-const isDevelopment = (): boolean => process.env.NODE_ENV === 'development';
-
-export { isDevelopment };
+export const isDevelopment = (): boolean => process.env.NODE_ENV === 'development';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6813,6 +6813,11 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
+dialog-polyfill@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dialog-polyfill/-/dialog-polyfill-0.5.4.tgz#e43bc54794a7fc605852352649bdd4d03cfb59e5"
+  integrity sha512-LqQvIky9+qIFD7MCESOXdMZc4ObCdEbzbuvnPJVCiRXKQMzMjpQKK50UI+2sj0bJBPKn6ugPpMRpuLrgYc4RjA==
+
 diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"


### PR DESCRIPTION
## What does this change?

* Makes the Grid integration visible by not blocklisting the `AppBanner` component.
* Create a signed image URL by calling the new [image signing service](https://github.com/guardian/image-url-signing-service) when an image URL is received from Grid.
* Checks that the user is logged in on the .gutools.co.uk domain and redirects to login.gutools.co.uk if not (you'll need to be logged in for requests to Grid and the image signing service to work).

## How to test

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
