### PR TITLE
Group stories by slot

### DIFF
--- a/src/AppBanner/index.stories.tsx
+++ b/src/AppBanner/index.stories.tsx
@@ -7,7 +7,7 @@ import { withGrid, grid } from '../../.storybook/grid/withGrid';
 
 export default {
     component: 'AppBanner',
-    title: 'Components/AppBanner',
+    title: 'Banner/AppBanner',
     decorators: [withGrid, withKnobs],
     parameters: {
         knobs: {
@@ -56,3 +56,5 @@ export const defaultStory = (): ReactElement => {
         </StorybookWrapper>
     );
 };
+
+defaultStory.story = { name: 'AppBanner' };

--- a/src/DigitalSubscriberAppBanner/index.stories.tsx
+++ b/src/DigitalSubscriberAppBanner/index.stories.tsx
@@ -6,7 +6,7 @@ import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'DigitalSubscriberAppBanner',
-    title: 'Components/DigitalSubscriberAppBanner',
+    title: 'Banner/DigitalSubscriberAppBanner',
     decorators: [withKnobs],
 };
 
@@ -44,4 +44,4 @@ export const defaultStory = (): ReactElement => {
     );
 };
 
-defaultStory.story = { name: 'Digital Subscriber App Banner' };
+defaultStory.story = { name: 'DigitalSubscriberAppBanner' };

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -9,7 +9,7 @@ const css = emotionReact.css;
 
 export default {
     component: 'Epic',
-    title: 'Components/Epic',
+    title: 'EndOfArticle/Epic',
     decorators: [withKnobs],
     parameters: {
         knobs: {},

--- a/src/SpecialEditionBanner/index.stories.tsx
+++ b/src/SpecialEditionBanner/index.stories.tsx
@@ -6,7 +6,7 @@ import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'SpecialEditionBanner',
-    title: 'Components/SpecialEditionBanner',
+    title: 'Banner/SpecialEditionBanner',
     decorators: [withKnobs],
     parameters: {
         knobs: {
@@ -49,4 +49,4 @@ export const defaultStory = (): ReactElement => {
     );
 };
 
-defaultStory.story = { name: 'Special Edition Banner' };
+defaultStory.story = { name: 'SpecialEditionBanner' };

--- a/src/TheGuardianIn2020Banner/index.stories.tsx
+++ b/src/TheGuardianIn2020Banner/index.stories.tsx
@@ -6,7 +6,7 @@ import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'TheGuardianIn2020Banner',
-    title: 'Components/TheGuardianIn2020Banner',
+    title: 'Banner/TheGuardianIn2020Banner',
     decorators: [withKnobs],
     parameters: {
         knobs: {
@@ -46,3 +46,5 @@ export const defaultStory = (): ReactElement => {
         </StorybookWrapper>
     );
 };
+
+defaultStory.story = { name: 'TheGuardianIn2020Banner' };


### PR DESCRIPTION
## What does this change?

We support two slots currently - Banner and EndOfArticle. It makes sense to group components in Storybook by these slots. Also setting the story name to match the component name seems to have the effect of removing an extra layer from the hierarchy which I think makes it simpler to navigate.

## How to test

`yarn storybook`

## Images

### Before

<img width="1552" alt="Screenshot 2021-07-01 at 16 58 58" src="https://user-images.githubusercontent.com/379839/124155020-f45e5980-da8d-11eb-9661-f558b208f650.png">

### After

<img width="1552" alt="Screenshot 2021-07-01 at 16 59 02" src="https://user-images.githubusercontent.com/379839/124154958-e27cb680-da8d-11eb-8e85-e1d54e3cce67.png">
