### PR TITLE
Rename local storybook host

### DIFF
--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -1,35 +1,48 @@
 const getEnvironment = () => {
     const hostname = window.location.hostname;
     switch (hostname) {
-        case 'braze-storybook.local.dev-gutools.co.uk': return 'LOCAL';
-        case 'braze-components.code.dev-gutools.co.uk': return 'CODE';
-        case 'braze-components.gutools.co.uk': return 'PROD';
-        default: throw `Could not determine environment for hostname ${hostname}`;
+        case 'braze-components.local.dev-gutools.co.uk':
+            return 'LOCAL';
+        case 'braze-components.code.dev-gutools.co.uk':
+            return 'CODE';
+        case 'braze-components.gutools.co.uk':
+            return 'PROD';
+        default:
+            throw `Could not determine environment for hostname ${hostname}`;
     }
-}
+};
 
 const getImageSigningUrl = () => {
     switch (getEnvironment()) {
-        case 'LOCAL': return 'https://image-url-signing-service.local.dev-gutools.co.uk';
-        case 'CODE': return 'https://image-url-signing-service.code.dev-gutools.co.uk';
-        case 'PROD': return 'https://image-url-signing-service.gutools.co.uk';
+        case 'LOCAL':
+            return 'https://image-url-signing-service.local.dev-gutools.co.uk';
+        case 'CODE':
+            return 'https://image-url-signing-service.code.dev-gutools.co.uk';
+        case 'PROD':
+            return 'https://image-url-signing-service.gutools.co.uk';
     }
 };
 
 const getGridUrl = () => {
     switch (getEnvironment()) {
-        case 'LOCAL': return 'https://media.test.dev-gutools.co.uk';
-        case 'CODE': return 'https://media.test.dev-gutools.co.uk';
-        case 'PROD': return 'https://media.gutools.co.uk';
+        case 'LOCAL':
+            return 'https://media.test.dev-gutools.co.uk';
+        case 'CODE':
+            return 'https://media.test.dev-gutools.co.uk';
+        case 'PROD':
+            return 'https://media.gutools.co.uk';
     }
-}
+};
 
 const getLoginUrl = () => {
     switch (getEnvironment()) {
-        case 'LOCAL': return 'https://login.local.dev-gutools.co.uk';
-        case 'CODE': return 'https://login.code.dev-gutools.co.uk';
-        case 'PROD': return 'https://login.gutools.co.uk';
+        case 'LOCAL':
+            return 'https://login.local.dev-gutools.co.uk';
+        case 'CODE':
+            return 'https://login.code.dev-gutools.co.uk';
+        case 'PROD':
+            return 'https://login.gutools.co.uk';
     }
-}
+};
 
 export { getGridUrl, getImageSigningUrl, getLoginUrl };

--- a/bin/storybook
+++ b/bin/storybook
@@ -3,7 +3,7 @@
 set -e # exit on error
 set -m # enable job control
 
-STORYBOOK_HOST=https://braze-storybook.local.dev-gutools.co.uk
+STORYBOOK_HOST=https://braze-components.local.dev-gutools.co.uk
 
 start-storybook -p 6016 --ci --no-manager-cache &
 yarn wait-on $STORYBOOK_HOST

--- a/nginx/nginx-mappings.yml
+++ b/nginx/nginx-mappings.yml
@@ -1,4 +1,4 @@
-name: braze-storybook
+name: braze-components
 mappings:
-    - prefix: braze-storybook
+    - prefix: braze-components
       port: 6016


### PR DESCRIPTION
## What does this change?

It keeps on confusing me that locally the subdomain for storybook is `braze-storybook` but everywhere else it's `braze-components`. Rename to be consistent with other environments.

## How to test

* `yarn storybook`
* visit https://braze-components.local.dev-gutools.co.uk/

