### PR TITLE
Use head request to check local login service

### DIFF
--- a/.storybook/gu-auth/register.js
+++ b/.storybook/gu-auth/register.js
@@ -2,17 +2,22 @@ import React from 'react';
 import { addons, types } from '@storybook/addons';
 
 import { GuAuth } from './GuAuth';
+import { skipAuth } from '../utils';
 
 const GU_AUTH_ADDON_ID = 'guAuthAddon';
 const GU_AUTH_PANEL_ID = `${GU_AUTH_ADDON_ID}/panel`;
 
-if (process.env.STORYBOOK_DISABLE_AUTH !== 'true') {
-    addons.register(GU_AUTH_ADDON_ID, () => {
-        addons.add(GU_AUTH_PANEL_ID, {
-            title: 'Gu Auth',
-            type: types.TOOL,
-            render: () => <GuAuth />,
-            paramKey: 'guAuth', // This is the key under which parameters are expected in the addon config
+skipAuth().then((skip) => {
+    if (!skip && process.env.STORYBOOK_DISABLE_AUTH !== 'true') {
+        addons.register(GU_AUTH_ADDON_ID, () => {
+            addons.add(GU_AUTH_PANEL_ID, {
+                title: 'Gu Auth',
+                type: types.TOOL,
+                render: () => <GuAuth />,
+                paramKey: 'guAuth', // This is the key under which parameters are expected in the addon config
+            });
         });
-    });
-}
+    } else {
+        console.log("Skipping auth requirement");
+    }
+});

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -45,4 +45,17 @@ const getLoginUrl = () => {
     }
 };
 
-export { getGridUrl, getImageSigningUrl, getLoginUrl };
+const skipAuth = async () => {
+    if (getEnvironment() === 'LOCAL') {
+        try {
+            const res = await fetch(getLoginUrl(), { method: 'HEAD' });
+            return res.status !== 200;
+        } catch (ex) {
+            console.log("Error calling local login.", ex);
+            return true;
+        }
+    }
+    return false;
+}
+
+export { getGridUrl, getImageSigningUrl, getLoginUrl, skipAuth };


### PR DESCRIPTION
Use HEAD request when running locally to check to see if local login service is online.
If not online then don't require login in storybook.﻿
