### PR TITLE
Fix broken epic rendering

### DIFF
--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -47,9 +47,14 @@ declare global {
 type EpicProps = {
     variant: Variant;
     tracking: Record<string, unknown>;
+    articleCounts: {
+        for52Weeks: number;
+        forTargetedWeeks: number;
+    };
 };
 
 type Variant = {
+    name: string;
     heading: string;
     paragraphs: Array<string>;
     highlightedText: string;
@@ -103,6 +108,7 @@ const Epic: React.FC<EpicProps> = (props) => {
 const buildProps = (data: DataFromKnobs): EpicProps => {
     return {
         variant: {
+            name: 'CONTROL',
             heading: data.heading,
             paragraphs: data.paragraphs,
             highlightedText: data.highlightedText,
@@ -111,7 +117,20 @@ const buildProps = (data: DataFromKnobs): EpicProps => {
                 baseUrl: data.buttonUrl,
             },
         },
-        tracking: {},
+        tracking: {
+            ophanPageId: 'xxxxxxxx',
+            platformId: 'GUARDIAN_WEB',
+            clientName: 'storybook',
+            referrerUrl: window.location.origin + window.location.pathname,
+            abTestName: '',
+            abTestVariant: '',
+            campaignCode: '',
+            componentType: 'ACQUISITIONS_EPIC',
+        },
+        articleCounts: {
+            for52Weeks: 0,
+            forTargetedWeeks: 0,
+        },
     };
 };
 


### PR DESCRIPTION
## What does this change?

The ContributionsEpic component added some validation to the passed props which we weren’t passing here. Add the missing props in so the component renders correctly.

## How to test

`yarn storybook`

## How can we measure success?

The epic component renders as expected in storybook.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before (no epic):

![Screenshot 2021-07-13 at 15 28 32](https://user-images.githubusercontent.com/379839/125470027-2fb4cd47-ad15-42d1-be67-e7090a937375.png)

After (an epic):

![Screenshot 2021-07-13 at 15 28 22](https://user-images.githubusercontent.com/379839/125470093-3e7068d0-4fdc-418b-a960-46ad825cc88d.png)


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
