### PR TITLE
Bump @braze/web-sdk-core NPM package to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
-    "@braze/web-sdk-core": "3.1.0",
+    "@braze/web-sdk-core": "3.3.0",
     "@emotion/babel-preset-css-prop": "^11.1.2",
     "@emotion/eslint-plugin": "^11.2.0",
     "@emotion/react": "^11.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,10 +2101,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@braze/web-sdk-core@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@braze/web-sdk-core/-/web-sdk-core-3.1.0.tgz#68bba5ba284dbe082229c0604b8d7e6da401feaa"
-  integrity sha512-Eillspp84rLX4NdjwMF11TJuWgwlrXwnUm2hgEtT8BdBO6CNvqh2mQBBbcgs2Y41CgleTsvwQwvuXI/TFrxDuQ==
+"@braze/web-sdk-core@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@braze/web-sdk-core/-/web-sdk-core-3.3.0.tgz#bfe299938525fd8501625fded49467b37db65e65"
+  integrity sha512-Gs5S4DkTlJsjxZzHeIw27jX1FfoaeM4IflxXx6l2ISXbIRP/UH4wlGUtp3Yvvf8gIwKjdLurekplcRMPvuF1gg==
 
 "@chromaui/localtunnel@2.0.1":
   version "2.0.1"


### PR DESCRIPTION
## What does this change?

Bump [`@braze/web-sdk-core`](https://www.npmjs.com/package/@braze/web-sdk-core) NPM package to 3.3.0. This is a dev dependency of this project. We import types in a few
places and also the `appboy` object in a test.


## How to test

`yarn test`
`yarn tsc`