### PR TITLE
Fix UKNewsletter `canRender` import

### DIFF
--- a/src/canRender.ts
+++ b/src/canRender.ts
@@ -33,7 +33,7 @@ import {
 import {
     COMPONENT_NAME as UK_NEWSLETTER_EPIC_NAME,
     canRender as ukNewsletterEpicCanRender,
-} from './AUNewsletterEpic/canRender';
+} from './UKNewsletterEpic/canRender';
 
 /** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
  * this means the user won't download the Braze components bundle when the component can't be shown.


### PR DESCRIPTION
## What does this change?

Fixes a tiny typo in the `canRender` import for `UKNewsletterEpic` which was preventing that newsletter from being seen as valid by the logic in `BrazeMessages` and so messages with this `componentName` wouldn't be rendered.
