### PR TITLE
Support clicking on the newsletter sign up button to subscribe

### DIFF
--- a/src/AUNewsletterEpic/index.stories.tsx
+++ b/src/AUNewsletterEpic/index.stories.tsx
@@ -41,6 +41,10 @@ export const defaultStory = (): ReactElement | null => {
                     paragraph1,
                     paragraph2,
                 }}
+                subscribeToNewsletter={(newsletterId) => {
+                    console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
+                    return new Promise((resolve) => setTimeout(resolve, 1000));
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/AUNewsletterEpic/index.tsx
+++ b/src/AUNewsletterEpic/index.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
-import { NewsletterEpic, BrazeMessageProps } from '../NewsletterEpic';
+import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
 import { BrazeClickHandler } from '../utils/tracking';
 import { OphanComponentEvent } from '@guardian/types';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/9f9f9c06ed5a323b13be816d5c160728c81d1bf9/0_0_784_784/784.png?width=196&s=4c4d5ff2c20821a6e6ff4d25f8ebcc16';
 
+const newsletterId = '4148';
+
+type BrazeMessageProps = {
+    header?: string;
+    frequency?: string;
+    paragraph1?: string;
+    paragraph2?: string;
+};
+
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
     ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
+    subscribeToNewsletter: NewsletterSubscribeCallback;
 };
 
 export const AUNewsletterEpic: React.FC<Props> = (props: Props) => {
@@ -22,7 +32,7 @@ export const AUNewsletterEpic: React.FC<Props> = (props: Props) => {
     return (
         <NewsletterEpic
             {...props}
-            brazeMessageProps={{ ...props.brazeMessageProps, imageUrl: IMAGE_URL }}
+            brazeMessageProps={{ ...props.brazeMessageProps, imageUrl: IMAGE_URL, newsletterId }}
         ></NewsletterEpic>
     );
 };

--- a/src/AppBanner/index.stories.tsx
+++ b/src/AppBanner/index.stories.tsx
@@ -52,6 +52,7 @@ export const defaultStory = (): ReactElement => {
                     imageUrl,
                     cta,
                 }}
+                subscribeToNewsletter={() => Promise.resolve()}
             />
         </StorybookWrapper>
     );

--- a/src/BrazeMessageComponent.test.tsx
+++ b/src/BrazeMessageComponent.test.tsx
@@ -20,6 +20,7 @@ describe('BrazeMessage', () => {
                 logButtonClickWithBraze={jest.fn()}
                 submitComponentEvent={jest.fn()}
                 brazeMessageProps={{}}
+                subscribeToNewsletter={() => Promise.resolve()}
             />,
         );
 
@@ -39,6 +40,7 @@ describe('BrazeMessage', () => {
                 logButtonClickWithBraze={jest.fn()}
                 submitComponentEvent={jest.fn()}
                 brazeMessageProps={{}}
+                subscribeToNewsletter={() => Promise.resolve()}
             />,
         );
 

--- a/src/BrazeMessageComponent.tsx
+++ b/src/BrazeMessageComponent.tsx
@@ -15,7 +15,11 @@ import {
 } from './TheGuardianIn2020Banner';
 import { BrazeClickHandler } from './utils/tracking';
 
-import { COMPONENT_NAME as NEWSLETTER_EPIC_NAME, NewsletterEpic } from './NewsletterEpic';
+import {
+    COMPONENT_NAME as NEWSLETTER_EPIC_NAME,
+    NewsletterEpic,
+    NewsletterSubscribeCallback,
+} from './NewsletterEpic';
 
 import { COMPONENT_NAME as US_NEWSLETTER_EPIC_NAME, USNewsletterEpic } from './USNewsletterEpic';
 
@@ -31,6 +35,7 @@ type CommonComponentProps = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
     brazeMessageProps: BrazeMessageProps;
+    subscribeToNewsletter: NewsletterSubscribeCallback;
 };
 
 type ComponentMapping = {
@@ -49,10 +54,11 @@ const COMPONENT_MAPPINGS: ComponentMapping = {
 };
 
 export type Props = {
+    componentName: string;
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
-    componentName: string;
     brazeMessageProps: BrazeMessageProps;
+    subscribeToNewsletter: (newsletterId: string) => Promise<void>;
 };
 
 export const buildBrazeMessageComponent = (mappings: ComponentMapping): React.FC<Props> => {
@@ -61,6 +67,7 @@ export const buildBrazeMessageComponent = (mappings: ComponentMapping): React.FC
         submitComponentEvent,
         componentName,
         brazeMessageProps,
+        subscribeToNewsletter,
     }: Props) => {
         const ComponentToRender = mappings[componentName];
 
@@ -72,6 +79,7 @@ export const buildBrazeMessageComponent = (mappings: ComponentMapping): React.FC
             <ComponentToRender
                 logButtonClickWithBraze={logButtonClickWithBraze}
                 submitComponentEvent={submitComponentEvent}
+                subscribeToNewsletter={subscribeToNewsletter}
                 brazeMessageProps={brazeMessageProps}
             />
         );

--- a/src/DigitalSubscriberAppBanner/index.stories.tsx
+++ b/src/DigitalSubscriberAppBanner/index.stories.tsx
@@ -38,6 +38,7 @@ export const defaultStory = (): ReactElement => {
                         header: header,
                         body: body,
                     }}
+                    subscribeToNewsletter={() => Promise.resolve()}
                 />
             </>
         </StorybookWrapper>

--- a/src/NewsletterEpic/canRender.ts
+++ b/src/NewsletterEpic/canRender.ts
@@ -3,7 +3,8 @@ import { BrazeMessageProps } from './index';
 export const COMPONENT_NAME = 'NewsletterEpic';
 
 export const canRender = (props: BrazeMessageProps): boolean => {
-    const { header, frequency, paragraph1, imageUrl } = props;
+    const { header, frequency, paragraph1, imageUrl, newsletterId } = props;
 
-    return Boolean(header && frequency && paragraph1 && imageUrl);
+    // TODO: validate the image URL as in AppBanner?
+    return Boolean(header && frequency && paragraph1 && imageUrl && newsletterId);
 };

--- a/src/NewsletterEpic/index.test.tsx
+++ b/src/NewsletterEpic/index.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { NewsletterEpic } from '.';
+
+describe('NewsletterEpic', () => {
+    describe('when the sign up button is clicked', () => {
+        const logButtonClickWithOphan = () => {
+            return;
+        };
+        const logButtonClickWithBraze = () => {
+            return;
+        };
+        const newsletterId = '4156';
+        const brazeMessageProps = {
+            header: 'First Thing',
+            frequency: 'Every day',
+            paragraph1: 'Start your day with...',
+            imageUrl:
+                'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/784.png?width=196&s=fbdead3f454e1ceeeab260ffde71100a',
+            newsletterId,
+        };
+
+        it('calls subscribeToNewsletter with the correct id', async () => {
+            const subscribeToNewsletter = jest.fn(() => Promise.resolve());
+
+            render(
+                <NewsletterEpic
+                    submitComponentEvent={logButtonClickWithOphan}
+                    logButtonClickWithBraze={logButtonClickWithBraze}
+                    brazeMessageProps={brazeMessageProps}
+                    subscribeToNewsletter={subscribeToNewsletter}
+                />,
+            );
+
+            fireEvent.click(screen.getByText('Sign up'));
+
+            await screen.findByText(/Thank you/);
+            expect(subscribeToNewsletter).toHaveBeenCalledWith(newsletterId);
+        });
+
+        it('renders thank you when successful', async () => {
+            const subscribeToNewsletter = () => Promise.resolve();
+
+            render(
+                <NewsletterEpic
+                    submitComponentEvent={logButtonClickWithOphan}
+                    logButtonClickWithBraze={logButtonClickWithBraze}
+                    brazeMessageProps={brazeMessageProps}
+                    subscribeToNewsletter={subscribeToNewsletter}
+                />,
+            );
+
+            fireEvent.click(screen.getByText('Sign up'));
+
+            await screen.findByText(/Thank you/);
+        });
+    });
+});

--- a/src/SpecialEditionBanner/index.stories.tsx
+++ b/src/SpecialEditionBanner/index.stories.tsx
@@ -43,6 +43,7 @@ export const defaultStory = (): ReactElement => {
                         header: header,
                         body: body,
                     }}
+                    subscribeToNewsletter={() => Promise.resolve()}
                 />
             </>
         </StorybookWrapper>

--- a/src/TheGuardianIn2020Banner/index.stories.tsx
+++ b/src/TheGuardianIn2020Banner/index.stories.tsx
@@ -42,6 +42,7 @@ export const defaultStory = (): ReactElement => {
                     header,
                     body,
                 }}
+                subscribeToNewsletter={() => Promise.resolve()}
             />
         </StorybookWrapper>
     );

--- a/src/UKNewsletterEpic/index.stories.tsx
+++ b/src/UKNewsletterEpic/index.stories.tsx
@@ -41,6 +41,10 @@ export const defaultStory = (): ReactElement | null => {
                     paragraph1,
                     paragraph2,
                 }}
+                subscribeToNewsletter={(newsletterId) => {
+                    console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
+                    return new Promise((resolve) => setTimeout(resolve, 1000));
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/UKNewsletterEpic/index.tsx
+++ b/src/UKNewsletterEpic/index.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
-import { NewsletterEpic, BrazeMessageProps } from '../NewsletterEpic';
+import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
 import { BrazeClickHandler } from '../utils/tracking';
 import { OphanComponentEvent } from '@guardian/types';
 
+const newsletterId = '4156';
+
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/1936.png?width=196&s=b8925f3e3a96a5b4f807e421b8a44906';
+
+type BrazeMessageProps = {
+    header?: string;
+    frequency?: string;
+    paragraph1?: string;
+    paragraph2?: string;
+};
 
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
     ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
+    subscribeToNewsletter: NewsletterSubscribeCallback;
 };
 
 export const UKNewsletterEpic: React.FC<Props> = (props: Props) => {
@@ -22,7 +32,7 @@ export const UKNewsletterEpic: React.FC<Props> = (props: Props) => {
     return (
         <NewsletterEpic
             {...props}
-            brazeMessageProps={{ ...props.brazeMessageProps, imageUrl: IMAGE_URL }}
+            brazeMessageProps={{ ...props.brazeMessageProps, imageUrl: IMAGE_URL, newsletterId }}
         ></NewsletterEpic>
     );
 };

--- a/src/USNewsletterEpic/index.stories.tsx
+++ b/src/USNewsletterEpic/index.stories.tsx
@@ -45,6 +45,10 @@ export const defaultStory = (): ReactElement | null => {
                     paragraph1,
                     paragraph2,
                 }}
+                subscribeToNewsletter={(newsletterId) => {
+                    console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
+                    return new Promise((resolve) => setTimeout(resolve, 1000));
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/USNewsletterEpic/index.tsx
+++ b/src/USNewsletterEpic/index.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
-import { NewsletterEpic, BrazeMessageProps } from '../NewsletterEpic';
+import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
 import { BrazeClickHandler } from '../utils/tracking';
 import { OphanComponentEvent } from '@guardian/types';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/784.png?width=196&s=fbdead3f454e1ceeeab260ffde71100a';
 
+const newsletterId = '4300';
+
+type BrazeMessageProps = {
+    header?: string;
+    frequency?: string;
+    paragraph1?: string;
+    paragraph2?: string;
+};
+
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
     ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
+    subscribeToNewsletter: NewsletterSubscribeCallback;
 };
 
 export const USNewsletterEpic: React.FC<Props> = (props: Props) => {
@@ -22,7 +32,7 @@ export const USNewsletterEpic: React.FC<Props> = (props: Props) => {
     return (
         <NewsletterEpic
             {...props}
-            brazeMessageProps={{ ...props.brazeMessageProps, imageUrl: IMAGE_URL }}
+            brazeMessageProps={{ ...props.brazeMessageProps, imageUrl: IMAGE_URL, newsletterId }}
         ></NewsletterEpic>
     );
 };


### PR DESCRIPTION
## What does this change?

This PR adds support for a `subscribeToNewsletter` prop to the newsletter epic components. This prop has the following type:

```ts
export type NewsletterSubscribeCallback = (id: string) => Promise<void>;
```

The implementation for this prop will be supplied by the platforms. The function is invoked when a user clicks on the "Sign up" button.

Note that the in-progress state and failures states aren't complete yet as we're waiting on design input.

## How to test

`yarn storybook`

## Images

![2021-07-15 13 34 16](https://user-images.githubusercontent.com/379839/125976267-a1deee6a-baf1-4d6f-9397-aac2c60d94f2.gif)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
