### PR TITLE
Update newsletter epic top border colour

### DIFF
--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -59,10 +59,10 @@ const styles = {
         margin-left: 4px;
     `,
     button: css`
-        background-color: #c70000;
-        color: #ffffff;
+        background-color: ${palette.news[400]};
+        color: ${palette.neutral[100]};
         &:hover {
-            background-color: #c70000;
+            background-color: ${palette.news[400]};
         }
     `,
     image: css`

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -31,7 +31,7 @@ const styles = {
         margin: 8px;
         padding: 4px 8px 12px;
         border-top: 1px solid ${palette.news[400]};
-        background-color: #f6f6f6;
+        background-color: ${palette.neutral[97]};
         display: flex;
         flex-direction: row;
         max-width: 620px;

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -30,7 +30,7 @@ const styles = {
     epicContainer: css`
         margin: 8px;
         padding: 4px 8px 12px;
-        border-top: 1px solid #ffe500;
+        border-top: 1px solid ${palette.news[400]};
         background-color: #f6f6f6;
         display: flex;
         flex-direction: row;

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -58,13 +58,6 @@ const styles = {
         ${textSans.medium()}
         margin-left: 4px;
     `,
-    button: css`
-        background-color: ${palette.news[400]};
-        color: ${palette.neutral[100]};
-        &:hover {
-            background-color: ${palette.news[400]};
-        }
-    `,
     image: css`
         width: 196px;
 
@@ -101,6 +94,13 @@ type CTAProps = {
 type SubscribeClickStatus = 'DEFAULT' | 'IN_PROGRESS' | 'SUCCESS' | 'FAILURE';
 
 const ctaStyles = {
+    button: css`
+        background-color: ${palette.news[400]};
+        color: ${palette.neutral[100]};
+        &:hover {
+            background-color: ${palette.news[400]};
+        }
+    `,
     thankYouText: css`
         ${body.medium({ fontWeight: 'bold' })}
         color: ${palette.neutral[0]}
@@ -129,7 +129,7 @@ const CTA: React.FC<CTAProps> = (props: CTAProps) => {
             return (
                 <ThemeProvider theme={buttonBrandAlt}>
                     <Button
-                        css={styles.button}
+                        css={ctaStyles.button}
                         onClick={() => {
                             setSubscribeClickStatus('IN_PROGRESS');
 
@@ -145,7 +145,7 @@ const CTA: React.FC<CTAProps> = (props: CTAProps) => {
         case 'IN_PROGRESS':
             return (
                 <ThemeProvider theme={buttonBrandAlt}>
-                    <Button css={styles.button} disabled={true}>
+                    <Button css={ctaStyles.button} disabled={true}>
                         Loading...
                     </Button>
                 </ThemeProvider>


### PR DESCRIPTION
## What does this change?

Updates the top border colour of the newsletter epic to match the Figma designs.

I've also updated a few places to use colour values from the design system.

## How to test

`yarn storybook`

## Images

### Before

<img width="645" alt="Screenshot 2021-07-22 at 09 58 39" src="https://user-images.githubusercontent.com/379839/126614217-db6b9e3d-30e3-4ddd-a2fb-226f9d1f4e4e.png">

### After

<img width="644" alt="Screenshot 2021-07-22 at 09 58 23" src="https://user-images.githubusercontent.com/379839/126614265-2dc606a6-8d5c-4ab5-bc31-430e579a5d87.png">


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
