### PR TITLE
Remove margins from both epics

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -23,7 +23,6 @@ const linkStyles = css`
 const styles = {
     epicWrapper: css`
         max-width: 620px;
-        margin: 10px;
     `,
     epicContainer: css`
         padding: 4px 8px 12px;

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -28,7 +28,6 @@ export const SvgClock = (): ReactElement => {
 
 const styles = {
     epicContainer: css`
-        margin: 8px;
         padding: 4px 8px 12px;
         border-top: 1px solid ${palette.news[400]};
         background-color: ${palette.neutral[97]};


### PR DESCRIPTION
## What does this change?

Removes some horizontal padding from both newsletter and contributions epic components. We noticed when rendered in the context of an article there was some extra whitespace we didn't want.

## Images

Newsletter epic example (note the spacing to the left and how the left edge of the component aligns with the article text):

### Before

<img width="656" alt="Screenshot 2021-07-23 at 09 29 19" src="https://user-images.githubusercontent.com/379839/126756692-a2565aee-c738-489c-90f1-67aeede476e8.png">

### After

<img width="678" alt="Screenshot 2021-07-23 at 09 27 03" src="https://user-images.githubusercontent.com/379839/126756716-4edb8595-09d8-4c21-8707-6368c8f38b8e.png">