### PR TITLE
Newsletter Epic Text Styling Tweaks

### DIFF
--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -25,8 +25,6 @@ export const SvgClock = (): ReactElement => {
     );
 };
 
-const bodyColor = '#666';
-
 const styles = {
     epicContainer: css`
         padding: 4px 8px 12px;
@@ -84,7 +82,7 @@ const styles = {
         line-height: 135%;
         margin: ${space[5]}px 0 ${space[5]}px;
         max-width: 100%;
-        color: ${bodyColor};
+        color: ${palette.neutral[0]};
 
         ${from.phablet} {
             max-width: 90%;

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -76,7 +76,6 @@ const styles = {
             max-width: 100%;
         }
     `,
-
     paragraph: css`
         ${body.medium()}
         line-height: 135%;
@@ -93,7 +92,6 @@ const styles = {
         }
 
         ${from.desktop} {
-            font-size: 20px;
             margin: ${space[3]}px 0 ${space[4]}px;
             max-width: 42rem;
         }

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -52,7 +52,7 @@ const styles = {
         }
     `,
     frequencyText: css`
-        color: #333333;
+        color: ${palette.neutral[20]};
         ${textSans.medium()}
         margin-left: 4px;
     `,

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -1,14 +1,13 @@
 import { css, ThemeProvider } from '@emotion/react';
 import React, { useState, ReactElement } from 'react';
-import { brand, palette } from '@guardian/src-foundations';
+import { brand, palette, space } from '@guardian/src-foundations';
 import { Button, buttonBrandAlt } from '@guardian/src-button';
-import { styles as commonStyles } from '../styles/bannerCommon';
 import { COMPONENT_NAME } from './canRender';
-import { body, textSans } from '@guardian/src-foundations/typography';
+import { body, headline, textSans } from '@guardian/src-foundations/typography';
 import { canRender } from './canRender';
 import { OphanComponentEvent } from '@guardian/types';
 import { BrazeClickHandler } from '../utils/tracking';
-import { until } from '@guardian/src-foundations/mq';
+import { from, until } from '@guardian/src-foundations/mq';
 
 // Once https://github.com/guardian/source/pull/843 is merged and in a
 // @guardian/src-icons release we'll be able to bump the version on this project
@@ -25,6 +24,8 @@ export const SvgClock = (): ReactElement => {
         </svg>
     );
 };
+
+const bodyColor = '#666';
 
 const styles = {
     epicContainer: css`
@@ -62,6 +63,49 @@ const styles = {
 
         ${until.desktop} {
             width: 96px;
+        }
+    `,
+    heading: css`
+        ${headline.small({ fontWeight: 'bold' })};
+        margin: 0;
+        max-width: 100%;
+
+        ${from.mobileLandscape} {
+            ${headline.small({ fontWeight: 'bold' })};
+        }
+
+        ${from.tablet} {
+            max-width: 100%;
+        }
+    `,
+
+    paragraph: css`
+        ${body.medium()}
+        line-height: 135%;
+        margin: ${space[5]}px 0 ${space[5]}px;
+        max-width: 100%;
+        color: ${bodyColor};
+
+        ${from.phablet} {
+            max-width: 90%;
+        }
+
+        ${from.tablet} {
+            max-width: 100%;
+        }
+
+        ${from.desktop} {
+            font-size: 20px;
+            margin: ${space[3]}px 0 ${space[4]}px;
+            max-width: 42rem;
+        }
+
+        ${from.leftCol} {
+            max-width: 37rem;
+        }
+
+        ${from.wide} {
+            max-width: 42rem;
         }
     `,
 };
@@ -183,15 +227,15 @@ export const NewsletterEpic: React.FC<Props> = (props: Props) => {
                     <img css={styles.image} src={imageUrl}></img>
                 </div>
                 <div css={styles.rightSection}>
-                    <span css={commonStyles.heading}>{header}</span>
+                    <span css={styles.heading}>{header}</span>
                     <div css={styles.frequencySection}>
                         <span css={styles.frequencyClock}>
                             <SvgClock />
                         </span>
                         <span css={styles.frequencyText}>{frequency}</span>
                     </div>
-                    <p css={commonStyles.paragraph}>{paragraph1}</p>
-                    {paragraph2 ? <p css={commonStyles.paragraph}>{paragraph2}</p> : null}
+                    <p css={styles.paragraph}>{paragraph1}</p>
+                    {paragraph2 ? <p css={styles.paragraph}>{paragraph2}</p> : null}
                     <CTA
                         subscribeToNewsletter={subscribeToNewsletter}
                         newsletterId={newsletterId as string}


### PR DESCRIPTION
## What does this change?

This PR contains minor tweaks to the newsletter epic text styles to more closely match the designs in Figma.

## How to test

`yarn storybook`

## Images

### Before

![Screenshot 2021-07-23 at 16 18 37](https://user-images.githubusercontent.com/379839/126804024-d19fc093-81f9-4d66-b70e-7301fe8a7a2a.png)

### After

![Screenshot 2021-07-23 at 16 18 08](https://user-images.githubusercontent.com/379839/126804061-5f868640-c0c1-480e-a228-6987bdb912ef.png)
