### PR TITLE
Update newsletter epic `canRender` functions

### DIFF
--- a/src/AUNewsletterEpic/canRender.ts
+++ b/src/AUNewsletterEpic/canRender.ts
@@ -1,9 +1,9 @@
-import { BrazeMessageProps } from '../NewsletterEpic';
+import { BrazeMessageProps } from '../AUNewsletterEpic';
 
 export const COMPONENT_NAME = 'AUNewsletterEpic';
 
 export const canRender = (props: BrazeMessageProps): boolean => {
-    const { header, frequency, paragraph1 } = props;
+    const { header, frequency, paragraph1, ophanComponentId } = props;
 
-    return Boolean(header && frequency && paragraph1);
+    return Boolean(header && frequency && paragraph1 && ophanComponentId);
 };

--- a/src/AUNewsletterEpic/index.stories.tsx
+++ b/src/AUNewsletterEpic/index.stories.tsx
@@ -24,6 +24,7 @@ export const defaultStory = (): ReactElement | null => {
         'We thought you should know this newsletter may contain information about Guardian products and services.',
     );
     const componentName = text('componentName', 'AUNewsletterEpic');
+    const ophanComponentId = text('ophanComponentId', 'example_ophan_component_id');
 
     return (
         <StorybookWrapper>
@@ -40,6 +41,7 @@ export const defaultStory = (): ReactElement | null => {
                     frequency,
                     paragraph1,
                     paragraph2,
+                    ophanComponentId,
                 }}
                 subscribeToNewsletter={(newsletterId) => {
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);

--- a/src/AUNewsletterEpic/index.tsx
+++ b/src/AUNewsletterEpic/index.tsx
@@ -9,17 +9,17 @@ const IMAGE_URL =
 
 const newsletterId = '4148';
 
-type BrazeMessageProps = {
+export type BrazeMessageProps = {
     header?: string;
     frequency?: string;
     paragraph1?: string;
     paragraph2?: string;
+    ophanComponentId?: string;
 };
 
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
-    ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
 };

--- a/src/NewsletterEpic/canRender.ts
+++ b/src/NewsletterEpic/canRender.ts
@@ -1,12 +1,17 @@
 import { BrazeMessageProps } from './index';
+import { isImageUrlAllowed } from '../utils/images';
 
 export const COMPONENT_NAME = 'NewsletterEpic';
 
 export const canRender = (props: BrazeMessageProps): boolean => {
     const { header, frequency, paragraph1, imageUrl, newsletterId, ophanComponentId } = props;
 
-    // TODO: validate the image URL as in AppBanner?
-    return Boolean(
-        header && frequency && paragraph1 && imageUrl && newsletterId && ophanComponentId,
-    );
+    if (!(header && frequency && paragraph1 && imageUrl && newsletterId && ophanComponentId)) {
+        return false;
+    }
+    if (!isImageUrlAllowed(imageUrl)) {
+        console.log(`Image URL ${imageUrl} is not allowed`);
+        return false;
+    }
+    return true;
 };

--- a/src/NewsletterEpic/canRender.ts
+++ b/src/NewsletterEpic/canRender.ts
@@ -3,8 +3,10 @@ import { BrazeMessageProps } from './index';
 export const COMPONENT_NAME = 'NewsletterEpic';
 
 export const canRender = (props: BrazeMessageProps): boolean => {
-    const { header, frequency, paragraph1, imageUrl, newsletterId } = props;
+    const { header, frequency, paragraph1, imageUrl, newsletterId, ophanComponentId } = props;
 
     // TODO: validate the image URL as in AppBanner?
-    return Boolean(header && frequency && paragraph1 && imageUrl && newsletterId);
+    return Boolean(
+        header && frequency && paragraph1 && imageUrl && newsletterId && ophanComponentId,
+    );
 };

--- a/src/NewsletterEpic/index.test.tsx
+++ b/src/NewsletterEpic/index.test.tsx
@@ -22,6 +22,7 @@ describe('NewsletterEpic', () => {
             imageUrl:
                 'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/784.png?width=196&s=fbdead3f454e1ceeeab260ffde71100a',
             newsletterId,
+            ophanComponentId: 'ophan_component_id',
         };
 
         it('calls subscribeToNewsletter with the correct id', async () => {

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -115,12 +115,12 @@ export type BrazeMessageProps = {
     paragraph2?: string;
     imageUrl?: string;
     newsletterId?: string;
+    ophanComponentId?: string;
 };
 
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
-    ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
 };

--- a/src/UKNewsletterEpic/canRender.ts
+++ b/src/UKNewsletterEpic/canRender.ts
@@ -1,9 +1,9 @@
-import { BrazeMessageProps } from '../NewsletterEpic';
+import { BrazeMessageProps } from '../UKNewsletterEpic';
 
 export const COMPONENT_NAME = 'UKNewsletterEpic';
 
 export const canRender = (props: BrazeMessageProps): boolean => {
-    const { header, frequency, paragraph1 } = props;
+    const { header, frequency, paragraph1, ophanComponentId } = props;
 
-    return Boolean(header && frequency && paragraph1);
+    return Boolean(header && frequency && paragraph1 && ophanComponentId);
 };

--- a/src/UKNewsletterEpic/index.stories.tsx
+++ b/src/UKNewsletterEpic/index.stories.tsx
@@ -24,6 +24,7 @@ export const defaultStory = (): ReactElement | null => {
         'We thought you should know this newsletter may contain information about Guardian products and services.',
     );
     const componentName = text('componentName', 'UKNewsletterEpic');
+    const ophanComponentId = text('ophanComponentId', 'example_ophan_component_id');
 
     return (
         <StorybookWrapper>
@@ -40,6 +41,7 @@ export const defaultStory = (): ReactElement | null => {
                     frequency,
                     paragraph1,
                     paragraph2,
+                    ophanComponentId,
                 }}
                 subscribeToNewsletter={(newsletterId) => {
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);

--- a/src/UKNewsletterEpic/index.tsx
+++ b/src/UKNewsletterEpic/index.tsx
@@ -9,17 +9,17 @@ const newsletterId = '4156';
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/1936.png?width=196&s=b8925f3e3a96a5b4f807e421b8a44906';
 
-type BrazeMessageProps = {
+export type BrazeMessageProps = {
     header?: string;
     frequency?: string;
     paragraph1?: string;
     paragraph2?: string;
+    ophanComponentId?: string;
 };
 
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
-    ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
 };

--- a/src/USNewsletterEpic/canRender.ts
+++ b/src/USNewsletterEpic/canRender.ts
@@ -1,9 +1,9 @@
-import { BrazeMessageProps } from '../NewsletterEpic';
+import { BrazeMessageProps } from '../USNewsletterEpic';
 
 export const COMPONENT_NAME = 'USNewsletterEpic';
 
 export const canRender = (props: BrazeMessageProps): boolean => {
-    const { header, frequency, paragraph1 } = props;
+    const { header, frequency, paragraph1, ophanComponentId } = props;
 
-    return Boolean(header && frequency && paragraph1);
+    return Boolean(header && frequency && paragraph1 && ophanComponentId);
 };

--- a/src/USNewsletterEpic/index.stories.tsx
+++ b/src/USNewsletterEpic/index.stories.tsx
@@ -28,6 +28,7 @@ export const defaultStory = (): ReactElement | null => {
         'We thought you should know this newsletter may contain information about Guardian products and services.',
     );
     const componentName = text('componentName', 'USNewsletterEpic');
+    const ophanComponentId = text('ophanComponentId', 'example_ophan_component_id');
 
     return (
         <StorybookWrapper>
@@ -44,6 +45,7 @@ export const defaultStory = (): ReactElement | null => {
                     frequency,
                     paragraph1,
                     paragraph2,
+                    ophanComponentId,
                 }}
                 subscribeToNewsletter={(newsletterId) => {
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);

--- a/src/USNewsletterEpic/index.tsx
+++ b/src/USNewsletterEpic/index.tsx
@@ -9,17 +9,17 @@ const IMAGE_URL =
 
 const newsletterId = '4300';
 
-type BrazeMessageProps = {
+export type BrazeMessageProps = {
     header?: string;
     frequency?: string;
     paragraph1?: string;
     paragraph2?: string;
+    ophanComponentId?: string;
 };
 
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
     submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
-    ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
 };


### PR DESCRIPTION
## What does this change?

This PR contains a couple of tweaks to the `canRender` function(s) of the newsletter epics:

* Make the `ophanComponentId` prop required in all cases, and move it to the key value pairs we get from Braze (as we do for the main contributions epic)
* Validate the `imageUrl` for the top level `BrazeNewsletterEpic` as we do for the `AppBanner` (there was a TODO in there for this which I wanted to get rid of!)
