### PR TITLE
Hide epic highlight if no text provided

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -94,7 +94,7 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                     {paragraphs.map((text, index) => (
                         <p key={'paragraph' + index} css={styles.paragraph}>
                             {text}
-                            {index === paragraphs.length - 1 ? (
+                            {highlightTextClean.length > 0 && index === paragraphs.length - 1 ? (
                                 <span css={styles.highlightText}>{highlightTextClean}</span>
                             ) : null}
                         </p>


### PR DESCRIPTION
## What does this change?
When no highlight text is provided to the braze epic, no empty highlight is shown. This matches the behaviour of the original contributions epic.

## How to test
In DCR code the text message has no highlight text and shows no highlight.

## How can we measure success?
No empty yellow highlight at bottom of epic paragraphs.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->