### PR TITLE
Package dialog-polyfill should be a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@typescript-eslint/parser": "^3.8.0",
     "babel-loader": "^8.1.0",
     "chromatic": "^5.1.0",
+    "dialog-polyfill": "^0.5.4",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
@@ -92,8 +93,7 @@
   "dependencies": {
     "@guardian/src-button": "3.3.0",
     "@guardian/src-foundations": "3.3.0",
-    "@guardian/src-icons": "3.3.0",
-    "dialog-polyfill": "^0.5.4"
+    "@guardian/src-icons": "3.3.0"
   },
   "np": {
     "branch": "main"


### PR DESCRIPTION
## What does this change?

Moves `dialog-polyfill` from `dependencies` to `devDependencies` - it's used by one of our storybook plugins. I noticed in guardian/dotcom-rendering#3209 that it ended up being pulled into the `yarn.lock` for that project which is potentially confusing/not what we want.
