### PR TITLE
Support HTML in paragraphs

### DIFF
--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -18,7 +18,7 @@ const TOTAL_PARAGRAPHS = 9;
 const defaultContent = {
     heading: 'Since you’re here...',
     paragraphs: [
-        '... we have a small favour to ask. More people, like you, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
+        '... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
         'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
         'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
         'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',

--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -93,7 +93,7 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                     <span css={styles.heading}>{heading}</span>
                     {paragraphs.map((text, index) => (
                         <p key={'paragraph' + index} css={styles.paragraph}>
-                            {text}
+                            <span dangerouslySetInnerHTML={{ __html: text }} />
                             {highlightTextClean.length > 0 && index === paragraphs.length - 1 ? (
                                 <span css={styles.highlightText}>{highlightTextClean}</span>
                             ) : null}


### PR DESCRIPTION
## What does this change?

We have use cases where there are links in the paragraph text. Before this change any HTML in the paragraph was escaped. This change makes us behave the same as the RRCP component which we’re switching away from.

Also add a link to the default props in storybook so that if this breaks in future Chromatic will let us know.

## How to test

Storybook.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

### Before

<img width="1552" alt="Screenshot 2021-07-29 at 11 17 51" src="https://user-images.githubusercontent.com/379839/127476833-3398d343-1614-4a2a-8307-1bc2683b3be1.png">

### After

<img width="1552" alt="Screenshot 2021-07-29 at 11 29 22" src="https://user-images.githubusercontent.com/379839/127476860-6f10ec2b-3c03-40bb-a89d-9f94b162a4bb.png">

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
