### PR TITLE
Fix invalid placeholder detection logic

### DIFF
--- a/src/Epic/canRender.ts
+++ b/src/Epic/canRender.ts
@@ -7,9 +7,9 @@ export const COMPONENT_NAME = 'Epic';
  * this means the user won't download the Braze components bundle when the component can't be shown.
  */
 export const canRenderEpic = (brazeMessageProps: BrazeMessageProps): boolean => {
-    const { heading, buttonText, buttonUrl, ophanComponentId } = brazeMessageProps;
+    const { buttonText, buttonUrl, ophanComponentId, highlightedText } = brazeMessageProps;
     const paragraphs = parseParagraphs(brazeMessageProps);
-    const allText = heading + ' ' + buttonText + ' ' + paragraphs.join(' ');
+    const allText = (highlightedText || '') + ' ' + paragraphs.join(' ');
     const invalidPlaceholders = containsNonAllowedPlaceholder(allText);
     return Boolean(
         buttonText &&

--- a/src/Epic/placeholders.test.ts
+++ b/src/Epic/placeholders.test.ts
@@ -1,0 +1,23 @@
+import { containsNonAllowedPlaceholder } from './placeholders';
+
+describe('containsNonAllowedPlaceholders', () => {
+    it('returns false when there are no placeholders', () => {
+        const got = containsNonAllowedPlaceholder('foo bar baz');
+        expect(got).toEqual(false);
+    });
+
+    it('returns false when there are only allowed placeholders', () => {
+        const got = containsNonAllowedPlaceholder('%%COUNTRY_NAME% foo bar baz');
+        expect(got).toEqual(false);
+    });
+
+    it('returns true when there are placeholders we do not support', () => {
+        const got = containsNonAllowedPlaceholder('%%FOO%% foo bar baz');
+        expect(got).toEqual(true);
+    });
+
+    it('returns true when there are both allowed and non-allowed placeholders', () => {
+        const got = containsNonAllowedPlaceholder('%%FOO%% %%COUNTRY_NAME%% foo bar baz');
+        expect(got).toEqual(true);
+    });
+});

--- a/src/Epic/placeholders.ts
+++ b/src/Epic/placeholders.ts
@@ -1,6 +1,6 @@
 import { getCountryName, getLocalCurrencySymbol } from './geolocation';
 
-const ALLOWED_PLACEHOLDERS = ['CURRENCY_SYMBOL', 'COUNTRY_NAME'];
+const ALLOWED_PLACEHOLDERS = ['%%CURRENCY_SYMBOL%%', '%%COUNTRY_NAME%%'];
 
 // we have to treat %%ARTICLE_COUNT%% placeholders specially as they are replaced
 // with react components, not a simple text substitution
@@ -25,6 +25,6 @@ const PLACEHOLDER_RE = /%%.*?%%/g;
 export const containsNonAllowedPlaceholder = (text: string): boolean => {
     const matches = text
         .match(PLACEHOLDER_RE)
-        ?.filter((str) => ALLOWED_PLACEHOLDERS.includes(`%%${str}%%`));
+        ?.filter((str) => !ALLOWED_PLACEHOLDERS.includes(`${str}`));
     return !!matches && matches.length > 0;
 };


### PR DESCRIPTION
## What does this change?

Fix the invalid placeholder detection logic and also added some tests as documentation. Previously the code to determine
whether there were any invalid placeholders was always returning false, this fixes the check so that invalid placeholders are correctly flagged.

The fields we support placeholder replacement in are the paragraphs and highlightedText. Update the call to `containsNonAllowedPlaceholder` in the canRender to reflect this.

## How to test

`yarn test`

You can also try out different placeholders in storybook. If an invalid one is used in the paragraphs or highlighted text the component won't render.
