### PR TITLE
Move Epic component story out of work-in-progress

### DIFF
--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -5,7 +5,7 @@ import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
 
 export default {
     component: 'Epic',
-    title: 'WorkInProgress/EndOfArticle/Epic',
+    title: 'EndOfArticle/Epic',
     decorators: [withKnobs],
     parameters: {
         knobs: {

--- a/src/ExternalEpic/index.stories.tsx
+++ b/src/ExternalEpic/index.stories.tsx
@@ -9,7 +9,7 @@ const css = emotionReact.css;
 
 export default {
     component: 'ExternalEpic',
-    title: 'EndOfArticle/ExternalEpic',
+    title: 'Deprecated/EndOfArticle/ExternalEpic',
     decorators: [withKnobs],
     parameters: {
         knobs: {},


### PR DESCRIPTION
## What does this change?

Move Epic component story our of work-in-progress. We're now using the new component in production. Move the old
ExternalEpic to deprecated for now. It feels like there might be occassions where it's useful to have this side by side with our Epic for now. We can probably remove in future.