### PR TITLE
Fix Storybook Gu Preview link for Epic

### DIFF
--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
+import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'Epic',
@@ -56,18 +57,22 @@ export const defaultStory = (): ReactElement | null => {
         }
     }
 
+    const brazeMessageProps = {
+        slotName,
+        ophanComponentId,
+        heading,
+        highlightedText,
+        buttonText,
+        buttonUrl,
+        ...paragraphMap,
+    };
+
+    knobsData.set({ ...brazeMessageProps, componentName });
+
     return (
         <StorybookWrapper>
             <BrazeEndOfArticleComponent
-                brazeMessageProps={{
-                    slotName,
-                    ophanComponentId,
-                    heading,
-                    highlightedText,
-                    buttonText,
-                    buttonUrl,
-                    ...paragraphMap,
-                }}
+                brazeMessageProps={brazeMessageProps}
                 componentName={componentName}
                 subscribeToNewsletter={() => Promise.resolve()}
             />


### PR DESCRIPTION
## What does this change?

For components in storybook we offer the ability to preview in place on the preview site via a custom Storybook plugin. This requires a little bit of wiring and it turns out we were missing it for the `Epic` component (I noticed this while attempting to troubleshoot an issue, which this would have made easier).

## How to test

Run storybook and click on the preview icon:

![2021-08-24 10 20 45](https://user-images.githubusercontent.com/379839/130591751-e5f3f300-75a0-4610-8c92-239ff1445660.gif)
