### PR TITLE
Fix Storybook Gu Preview for newsletter epics

### DIFF
--- a/src/AUNewsletterEpic/index.stories.tsx
+++ b/src/AUNewsletterEpic/index.stories.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { withKnobs, text } from '@storybook/addon-knobs';
+import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'AUNewsletterEpic',
@@ -26,17 +27,21 @@ export const defaultStory = (): ReactElement | null => {
     const componentName = text('componentName', 'AUNewsletterEpic');
     const ophanComponentId = text('ophanComponentId', 'example_ophan_component_id');
 
+    const brazeMessageProps = {
+        header,
+        frequency,
+        paragraph1,
+        paragraph2,
+        ophanComponentId,
+    };
+
+    knobsData.set({ ...brazeMessageProps, componentName });
+
     return (
         <StorybookWrapper>
             <BrazeEndOfArticleComponent
                 componentName={componentName}
-                brazeMessageProps={{
-                    header,
-                    frequency,
-                    paragraph1,
-                    paragraph2,
-                    ophanComponentId,
-                }}
+                brazeMessageProps={brazeMessageProps}
                 subscribeToNewsletter={(newsletterId) => {
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
                     return new Promise((resolve) => setTimeout(resolve, 1000));

--- a/src/UKNewsletterEpic/index.stories.tsx
+++ b/src/UKNewsletterEpic/index.stories.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { withKnobs, text } from '@storybook/addon-knobs';
+import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'UKNewsletterEpic',
@@ -26,17 +27,21 @@ export const defaultStory = (): ReactElement | null => {
     const componentName = text('componentName', 'UKNewsletterEpic');
     const ophanComponentId = text('ophanComponentId', 'example_ophan_component_id');
 
+    const brazeMessageProps = {
+        header,
+        frequency,
+        paragraph1,
+        paragraph2,
+        ophanComponentId,
+    };
+
+    knobsData.set({ ...brazeMessageProps, componentName });
+
     return (
         <StorybookWrapper>
             <BrazeEndOfArticleComponent
                 componentName={componentName}
-                brazeMessageProps={{
-                    header,
-                    frequency,
-                    paragraph1,
-                    paragraph2,
-                    ophanComponentId,
-                }}
+                brazeMessageProps={brazeMessageProps}
                 subscribeToNewsletter={(newsletterId) => {
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
                     return new Promise((resolve) => setTimeout(resolve, 1000));

--- a/src/USNewsletterEpic/index.stories.tsx
+++ b/src/USNewsletterEpic/index.stories.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
 import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { withKnobs, text } from '@storybook/addon-knobs';
+import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'USNewsletterEpic',
@@ -30,17 +31,21 @@ export const defaultStory = (): ReactElement | null => {
     const componentName = text('componentName', 'USNewsletterEpic');
     const ophanComponentId = text('ophanComponentId', 'example_ophan_component_id');
 
+    const brazeMessageProps = {
+        header,
+        frequency,
+        paragraph1,
+        paragraph2,
+        ophanComponentId,
+    };
+
+    knobsData.set({ ...brazeMessageProps, componentName });
+
     return (
         <StorybookWrapper>
             <BrazeEndOfArticleComponent
                 componentName={componentName}
-                brazeMessageProps={{
-                    header,
-                    frequency,
-                    paragraph1,
-                    paragraph2,
-                    ophanComponentId,
-                }}
+                brazeMessageProps={brazeMessageProps}
                 subscribeToNewsletter={(newsletterId) => {
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
                     return new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
## What does this change?

Follow up to #218. Fix the GuPreview storybook link for newsletter epics.

## How to test

Run storybook and click on the preview icon.