### PR TITLE
Add EpicWithHeaderImage component

### DIFF
--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -7,12 +7,13 @@ import {
 } from './NewsletterEpic';
 
 import { COMPONENT_NAME as US_NEWSLETTER_EPIC_NAME, USNewsletterEpic } from './USNewsletterEpic';
-
 import { COMPONENT_NAME as AU_NEWSLETTER_EPIC_NAME, AUNewsletterEpic } from './AUNewsletterEpic';
-
 import { COMPONENT_NAME as UK_NEWSLETTER_EPIC_NAME, UKNewsletterEpic } from './UKNewsletterEpic';
-
 import { COMPONENT_NAME as EPIC_NAME, Epic } from './Epic';
+import {
+    COMPONENT_NAME as EPIC_WITH_HEADER_IMAGE_NAME,
+    EpicWithHeaderImage,
+} from './EpicWithHeaderImage';
 import { buildBrazeMessageComponent, ComponentMapping } from './buildBrazeMessageComponent';
 
 type BrazeMessageProps = {
@@ -32,6 +33,7 @@ const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps
     [AU_NEWSLETTER_EPIC_NAME]: AUNewsletterEpic,
     [UK_NEWSLETTER_EPIC_NAME]: UKNewsletterEpic,
     [EPIC_NAME]: Epic,
+    [EPIC_WITH_HEADER_IMAGE_NAME]: EpicWithHeaderImage,
 };
 
 export const BrazeEndOfArticleComponent: React.FC<CommonEndOfArticleComponentProps> =

--- a/src/Epic/canRender.test.ts
+++ b/src/Epic/canRender.test.ts
@@ -1,7 +1,7 @@
-import { canRenderEpic } from './canRender';
+import { canRender } from './canRender';
 import { BrazeMessageProps } from './index';
 
-describe('canRenderEpic', () => {
+describe('canRender', () => {
     it('returns true when data from Braze is valid', () => {
         const dataFromBraze: BrazeMessageProps = {
             heading: 'Example Heading',
@@ -14,7 +14,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(true);
     });
@@ -30,7 +30,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(true);
     });
@@ -45,7 +45,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(true);
     });
@@ -58,7 +58,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -74,7 +74,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -89,7 +89,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -104,7 +104,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -119,7 +119,7 @@ describe('canRenderEpic', () => {
             buttonUrl: 'https://www.example.com',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -133,7 +133,7 @@ describe('canRenderEpic', () => {
             buttonUrl: 'https://www.example.com',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });

--- a/src/Epic/canRender.ts
+++ b/src/Epic/canRender.ts
@@ -6,11 +6,12 @@ export const COMPONENT_NAME = 'Epic';
 /** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
  * this means the user won't download the Braze components bundle when the component can't be shown.
  */
-export const canRenderEpic = (brazeMessageProps: BrazeMessageProps): boolean => {
+export const canRender = (brazeMessageProps: BrazeMessageProps): boolean => {
     const { buttonText, buttonUrl, ophanComponentId, highlightedText } = brazeMessageProps;
     const paragraphs = parseParagraphs(brazeMessageProps);
     const allText = (highlightedText || '') + ' ' + paragraphs.join(' ');
     const invalidPlaceholders = containsNonAllowedPlaceholder(allText);
+
     return Boolean(
         buttonText &&
             buttonUrl &&

--- a/src/EpicWithHeaderImage/canRender.ts
+++ b/src/EpicWithHeaderImage/canRender.ts
@@ -1,0 +1,3 @@
+export { canRender } from '../Epic/canRender';
+
+export const COMPONENT_NAME = 'EpicWithHeaderImage';

--- a/src/EpicWithHeaderImage/index.stories.tsx
+++ b/src/EpicWithHeaderImage/index.stories.tsx
@@ -3,19 +3,18 @@ import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
 import { knobsData } from '../utils/knobsData';
 import {
-    buildEpicParagraphDocs,
     coreArgTypes,
     ophanComponentIdArgType,
+    buildEpicParagraphDocs,
 } from '../storybookCommon/argTypes';
-import { BrazeMessageProps } from '.';
+import { BrazeMessageProps } from '../Epic';
 
 const NUMBER_OF_PARAGRAPHS = 9;
 const paragraphDocs = buildEpicParagraphDocs(NUMBER_OF_PARAGRAPHS);
 
 export default {
-    component: 'Epic',
-    title: 'EndOfArticle/Epic',
-    parameters: {},
+    component: 'EpicWithHeaderImage',
+    title: 'WorkInProgress/EndOfArticle/EpicWithHeaderImage',
     argTypes: {
         ...coreArgTypes,
         ...ophanComponentIdArgType,
@@ -95,7 +94,7 @@ DefaultStory.args = {
     buttonUrl: 'https://support.theguardian.com/contribute',
     ophanComponentId: 'example_ophan_component_id',
     slotName: 'EndOfArticle',
-    componentName: 'Epic',
+    componentName: 'EpicWithHeaderImage',
 };
 
-DefaultStory.story = { name: 'Epic' };
+DefaultStory.story = { name: 'EpicWithHeaderImage' };

--- a/src/EpicWithHeaderImage/index.tsx
+++ b/src/EpicWithHeaderImage/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Epic } from '../Epic';
+import type { EpicProps } from '../Epic';
+
+export { COMPONENT_NAME } from './canRender';
+
+const HEADER_IMAGE_URL =
+    'https://i.guim.co.uk/img/media/6c8bb5d11501239615157e16e98b56018978578b/0_0_2953_2282/master/2953.jpg?width=1010&quality=45&auto=format&fit=max&dpr=2&s=8a01d64171d5bb3083b5b59a4081cde3';
+
+export const EpicWithHeaderImage: React.FC<EpicProps> = (props: EpicProps) => (
+    <Epic {...props} headerImageUrl={HEADER_IMAGE_URL} />
+);

--- a/src/canRender.ts
+++ b/src/canRender.ts
@@ -14,7 +14,7 @@ import {
     COMPONENT_NAME as SPECIAL_EDITION_BANNER_NAME,
     canRender as specialEdCanRender,
 } from './SpecialEditionBanner/canRender';
-import { canRenderEpic } from './Epic/canRender';
+import { COMPONENT_NAME as EPIC_NAME, canRender as epicCanRender } from './Epic/canRender';
 import {
     COMPONENT_NAME as NEWSLETTER_EPIC_NAME,
     canRender as newsletterEpicCanRender,
@@ -35,6 +35,11 @@ import {
     canRender as ukNewsletterEpicCanRender,
 } from './UKNewsletterEpic/canRender';
 
+import {
+    COMPONENT_NAME as EPIC_WITH_IMAGE_NAME,
+    canRender as epicWithImageCanRender,
+} from './EpicWithHeaderImage/canRender';
+
 /** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
  * this means the user won't download the Braze components bundle when the component can't be shown.
  */
@@ -49,11 +54,12 @@ const COMPONENT_CAN_RENDER_MAPPINGS: Record<
     [DIGITAL_SUBSCRIBER_APP_BANNER_NAME]: digitialSubCanRender,
     [SPECIAL_EDITION_BANNER_NAME]: specialEdCanRender,
     [THE_GUARDIAN_IN_2020_BANNER_NAME]: gIn2020BannerCanRender,
-    Epic: canRenderEpic,
+    [EPIC_NAME]: epicCanRender,
     [NEWSLETTER_EPIC_NAME]: newsletterEpicCanRender,
     [US_NEWSLETTER_EPIC_NAME]: usNewsletterEpicCanRender,
     [AU_NEWSLETTER_EPIC_NAME]: auNewsletterEpicCanRender,
     [UK_NEWSLETTER_EPIC_NAME]: ukNewsletterEpicCanRender,
+    [EPIC_WITH_IMAGE_NAME]: epicWithImageCanRender,
 };
 
 export const canRenderBrazeMsg = (msgExtras: Extras | undefined): boolean => {

--- a/src/storybookCommon/argTypes.ts
+++ b/src/storybookCommon/argTypes.ts
@@ -29,3 +29,23 @@ export const ophanComponentIdArgType = {
             '`rc_upsell_test1_variant`.',
     },
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const buildEpicParagraphDocs = (
+    numberOfParagraphs: number,
+): [string, Record<string, unknown>][] =>
+    Array.from({ length: numberOfParagraphs }, (_, idx) => {
+        const name = `paragraph${idx + 1}`;
+        return [
+            name,
+            {
+                name,
+                type: {
+                    name: 'string',
+                    required: idx === 0,
+                },
+                description:
+                    'Paragraph text. Supports HTML. If adding links see Braze user guide for tracking params.',
+            },
+        ];
+    });


### PR DESCRIPTION
## What does this change?

This PR adds a new component `EpicWithHeaderImage`. The new component is implemented on top of the existing `Epic` component, passing through a hardcoded image URL. The image URL isn't part of the Braze message props in the existing `Epic`, so there's no way to pass it through from Braze (i.e. it's private for now, which is what we want).

We’re treating our first usage of the epic with an image as an experiment, so short term we’ll hardcode the image avoiding the overhead of adding proper image support (via the picker). If the test goes well we can make headerImageUrl a properly supported part of the `Epic` component.

https://trello.com/c/xODg9J4r/1217-new-epic-template-with-image

## How to test

In Storybook, there's a new story `EpicWithHeaderImage` under `WorkInProgress/EndOfArticle`.

## How can we measure success?

We'll be running a test to validate the image usage.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Actual image TBC (sadly the cats aren't it)!

![Screenshot 2021-09-08 at 10 58 40](https://user-images.githubusercontent.com/379839/132489094-4bf244f6-4e46-4c66-9beb-5a6a590e417d.png)

<img width="254" alt="Screenshot 2021-08-27 at 16 44 06" src="https://user-images.githubusercontent.com/379839/131153800-617ca212-9376-4242-81c1-bcd1f2beedde.png">

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
