### PR TITLE
Use master crop image source for transformations

### DIFF
--- a/src/AUNewsletterEpic/index.tsx
+++ b/src/AUNewsletterEpic/index.tsx
@@ -3,7 +3,7 @@ import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
 
 const IMAGE_URL =
-    'https://i.guim.co.uk/img/media/9f9f9c06ed5a323b13be816d5c160728c81d1bf9/0_0_784_784/784.png?width=196&s=4c4d5ff2c20821a6e6ff4d25f8ebcc16';
+    'https://i.guim.co.uk/img/media/9f9f9c06ed5a323b13be816d5c160728c81d1bf9/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=87f06d1d5322f1fb8e2262d202f70e99';
 
 const newsletterId = '4148';
 

--- a/src/UKNewsletterEpic/index.tsx
+++ b/src/UKNewsletterEpic/index.tsx
@@ -5,7 +5,7 @@ import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
 const newsletterId = '4156';
 
 const IMAGE_URL =
-    'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/1936.png?width=196&s=b8925f3e3a96a5b4f807e421b8a44906';
+    'https://i.guim.co.uk/img/media/568c6031be78dab6f6c28336010884f3ebd0f97c/0_0_1936_1936/master/1936.png?width=196&quality=45&auto=format&s=2a3630e9625620d5726c31c5cdbf4772';
 
 export type BrazeMessageProps = {
     header?: string;

--- a/src/USNewsletterEpic/index.tsx
+++ b/src/USNewsletterEpic/index.tsx
@@ -3,7 +3,7 @@ import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
 
 const IMAGE_URL =
-    'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/784.png?width=196&s=fbdead3f454e1ceeeab260ffde71100a';
+    'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=cca73e857c5093f39ef7a2a9dc2e7ce7';
 
 const newsletterId = '4300';
 


### PR DESCRIPTION


## What does this change?

Updates the image transformation params we're using for newsletter epic images.

From talking to other developers who understand the image transformation service well, we should always be using the master crop as the source for image transformations.

I've also added in the quality and auto=format params. Auto format does causes the image transformation service to do the right thing with regards to converting to either webp or png8.

My goal when looking at the transformations we were applying was to see if I could get the image size down any further, which I wasn't successful in doing. Of the three images two a very marginally smaller and one is very marginally larger than what we had before. I think we should merge this anyway as it's slightly more correct than what we had previously.

## How to test

`yarn storybook`