### PR TITLE
Newsletter epic stories no longer work-in-progress

### DIFF
--- a/src/AUNewsletterEpic/index.stories.tsx
+++ b/src/AUNewsletterEpic/index.stories.tsx
@@ -6,7 +6,7 @@ import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'AUNewsletterEpic',
-    title: 'WorkInProgress/EndOfArticle/AUNewsletterEpic',
+    title: 'EndOfArticle/AUNewsletterEpic',
     decorators: [withKnobs({ escapeHTML: false })],
     parameters: {},
 };

--- a/src/UKNewsletterEpic/index.stories.tsx
+++ b/src/UKNewsletterEpic/index.stories.tsx
@@ -6,7 +6,7 @@ import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'UKNewsletterEpic',
-    title: 'WorkInProgress/EndOfArticle/UKNewsletterEpic',
+    title: 'EndOfArticle/UKNewsletterEpic',
     decorators: [withKnobs({ escapeHTML: false })],
     parameters: {},
 };

--- a/src/USNewsletterEpic/index.stories.tsx
+++ b/src/USNewsletterEpic/index.stories.tsx
@@ -6,7 +6,7 @@ import { knobsData } from '../utils/knobsData';
 
 export default {
     component: 'USNewsletterEpic',
-    title: 'WorkInProgress/EndOfArticle/USNewsletterEpic',
+    title: 'EndOfArticle/USNewsletterEpic',
     decorators: [
         withKnobs({
             escapeHTML: false,


### PR DESCRIPTION
## What does this change?

Moves the newsletter epic stories out of `WorkInProgress` as they are now ready to use.

## How to test

`yarn storybook`