### PR TITLE
Fix a warning emitted by jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     transformIgnorePatterns: ['/node_modules/(?!(@guardian)/)'],
     globals: {
         'ts-jest': {
-            tsConfig: 'tsconfig.test.json',
+            tsconfig: 'tsconfig.test.json',
         },
     },
 };


### PR DESCRIPTION
## What does this change?

Fixes a warning from jest. There were previously multiple instances of:

```
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
```