### PR TITLE
Add EpicWithSpecialHeader

### DIFF
--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -7,12 +7,13 @@ import {
 } from './NewsletterEpic';
 
 import { COMPONENT_NAME as US_NEWSLETTER_EPIC_NAME, USNewsletterEpic } from './USNewsletterEpic';
-
 import { COMPONENT_NAME as AU_NEWSLETTER_EPIC_NAME, AUNewsletterEpic } from './AUNewsletterEpic';
-
 import { COMPONENT_NAME as UK_NEWSLETTER_EPIC_NAME, UKNewsletterEpic } from './UKNewsletterEpic';
-
 import { COMPONENT_NAME as EPIC_NAME, Epic } from './Epic';
+import {
+    COMPONENT_NAME as EPIC_WITH_HEADER_IMAGE_NAME,
+    EpicWithSpecialHeader,
+} from './EpicWithSpecialHeader';
 import { buildBrazeMessageComponent, ComponentMapping } from './buildBrazeMessageComponent';
 
 type BrazeMessageProps = {
@@ -32,6 +33,7 @@ const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps
     [AU_NEWSLETTER_EPIC_NAME]: AUNewsletterEpic,
     [UK_NEWSLETTER_EPIC_NAME]: UKNewsletterEpic,
     [EPIC_NAME]: Epic,
+    [EPIC_WITH_HEADER_IMAGE_NAME]: EpicWithSpecialHeader,
 };
 
 export const BrazeEndOfArticleComponent: React.FC<CommonEndOfArticleComponentProps> =

--- a/src/Epic/canRender.test.ts
+++ b/src/Epic/canRender.test.ts
@@ -1,7 +1,7 @@
-import { canRenderEpic } from './canRender';
+import { canRender } from './canRender';
 import { BrazeMessageProps } from './index';
 
-describe('canRenderEpic', () => {
+describe('canRender', () => {
     it('returns true when data from Braze is valid', () => {
         const dataFromBraze: BrazeMessageProps = {
             heading: 'Example Heading',
@@ -14,7 +14,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(true);
     });
@@ -30,7 +30,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(true);
     });
@@ -45,7 +45,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(true);
     });
@@ -58,7 +58,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -74,7 +74,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -89,7 +89,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -104,7 +104,7 @@ describe('canRenderEpic', () => {
             ophanComponentId: 'epic_123',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -119,7 +119,7 @@ describe('canRenderEpic', () => {
             buttonUrl: 'https://www.example.com',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });
@@ -133,7 +133,7 @@ describe('canRenderEpic', () => {
             buttonUrl: 'https://www.example.com',
         };
 
-        const got = canRenderEpic(dataFromBraze);
+        const got = canRender(dataFromBraze);
 
         expect(got).toEqual(false);
     });

--- a/src/Epic/canRender.ts
+++ b/src/Epic/canRender.ts
@@ -6,11 +6,12 @@ export const COMPONENT_NAME = 'Epic';
 /** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
  * this means the user won't download the Braze components bundle when the component can't be shown.
  */
-export const canRenderEpic = (brazeMessageProps: BrazeMessageProps): boolean => {
+export const canRender = (brazeMessageProps: BrazeMessageProps): boolean => {
     const { buttonText, buttonUrl, ophanComponentId, highlightedText } = brazeMessageProps;
     const paragraphs = parseParagraphs(brazeMessageProps);
     const allText = (highlightedText || '') + ' ' + paragraphs.join(' ');
     const invalidPlaceholders = containsNonAllowedPlaceholder(allText);
+
     return Boolean(
         buttonText &&
             buttonUrl &&

--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { brand, palette, space } from '@guardian/src-foundations';
 import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { body, headline } from '@guardian/src-foundations/typography';
-import { COMPONENT_NAME, canRenderEpic, parseParagraphs } from './canRender';
+import { COMPONENT_NAME, canRender, parseParagraphs } from './canRender';
 export { COMPONENT_NAME };
 import { replaceNonArticleCountPlaceholders } from './placeholders';
 
@@ -23,7 +23,7 @@ const styles = {
         max-width: 620px;
     `,
     epicContainer: css`
-        padding: 4px 8px 12px;
+        padding: ${space[1]}px ${space[2]}px ${space[3]}px;
         border-top: 1px solid #ffe500;
         background-color: #f6f6f6;
         display: flex;
@@ -68,15 +68,17 @@ export type EpicProps = {
     ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
     countryCode?: string;
+    headerSection?: React.ReactNode;
 };
 
 export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
     const {
         brazeMessageProps: { heading, buttonText, buttonUrl, highlightedText },
         countryCode,
+        headerSection,
     } = props;
 
-    if (!canRenderEpic(props.brazeMessageProps)) {
+    if (!canRender(props.brazeMessageProps)) {
         return null;
     }
 
@@ -90,6 +92,8 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
         <ThemeProvider theme={brand}>
             <div css={styles.epicWrapper}>
                 <section css={styles.epicContainer}>
+                    {headerSection}
+
                     <span css={styles.heading}>{heading}</span>
                     {paragraphs.map((text, index) => (
                         <p key={'paragraph' + index} css={styles.paragraph}>

--- a/src/EpicWithSpecialHeader/canRender.ts
+++ b/src/EpicWithSpecialHeader/canRender.ts
@@ -1,0 +1,3 @@
+export { canRender } from '../Epic/canRender';
+
+export const COMPONENT_NAME = 'EpicWithSpecialHeader';

--- a/src/EpicWithSpecialHeader/index.stories.tsx
+++ b/src/EpicWithSpecialHeader/index.stories.tsx
@@ -3,19 +3,18 @@ import { StorybookWrapper } from '../utils/StorybookWrapper';
 import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
 import { knobsData } from '../utils/knobsData';
 import {
-    buildEpicParagraphDocs,
     coreArgTypes,
     ophanComponentIdArgType,
+    buildEpicParagraphDocs,
 } from '../storybookCommon/argTypes';
-import { BrazeMessageProps } from '.';
+import { BrazeMessageProps } from '../Epic';
 
 const NUMBER_OF_PARAGRAPHS = 9;
 const paragraphDocs = buildEpicParagraphDocs(NUMBER_OF_PARAGRAPHS);
 
 export default {
-    component: 'Epic',
-    title: 'EndOfArticle/Epic',
-    parameters: {},
+    component: 'EpicWithSpecialHeader',
+    title: 'WorkInProgress/EndOfArticle/EpicWithSpecialHeader',
     argTypes: {
         ...coreArgTypes,
         ...ophanComponentIdArgType,
@@ -80,7 +79,6 @@ const StoryTemplate = (
 export const DefaultStory = StoryTemplate.bind({});
 
 DefaultStory.args = {
-    heading: 'Since you’re here...',
     paragraph1:
         '... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
     paragraph2:
@@ -95,7 +93,7 @@ DefaultStory.args = {
     buttonUrl: 'https://support.theguardian.com/contribute',
     ophanComponentId: 'example_ophan_component_id',
     slotName: 'EndOfArticle',
-    componentName: 'Epic',
+    componentName: 'EpicWithSpecialHeader',
 };
 
-DefaultStory.story = { name: 'Epic' };
+DefaultStory.story = { name: 'EpicWithSpecialHeader' };

--- a/src/EpicWithSpecialHeader/index.tsx
+++ b/src/EpicWithSpecialHeader/index.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { from, breakpoints } from '@guardian/src-foundations/mq';
+import { space } from '@guardian/src-foundations';
+import { body, headline } from '@guardian/src-foundations/typography';
+
+import { Epic } from '../Epic';
+import type { EpicProps } from '../Epic';
+
+export { COMPONENT_NAME } from './canRender';
+
+const HEADER_IMAGE_URL =
+    'https://i.guim.co.uk/img/media/cecfef4098a2a8c1e302e3f67b979f11ee529bb6/0_0_470_471/master/470.png?width=300&quality=45&s=d654e72595c07e2095777863f4901863';
+
+const emptyImage = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+
+const headerStyles = {
+    picture: css``,
+    rightContainer: css`
+        flex: 1;
+    `,
+    image: css`
+        height: auto;
+        width: 100%;
+        object-fit: cover;
+    `,
+    container: css`
+        display: none;
+
+        ${from.tablet} {
+            display: flex;
+            align-items: center;
+            padding: ${space[1]}px ${space[1]}px 0;
+        }
+    `,
+    leftContainer: css`
+        flex: 3;
+        margin-right: ${space[4]}px;
+    `,
+    text: css`
+        ${headline.large({ fontWeight: 'bold' })};
+        line-height: 1.35;
+    `,
+    imageCaptionContainer: css``,
+    imageCaption: css`
+        ${body.medium()}
+        margin: 0;
+    `,
+    imageCaptionBold: css`
+        ${body.medium({ fontWeight: 'bold' })}
+    `,
+    imageCaptionItalic: css`
+        ${body.medium({ fontStyle: 'italic' })}
+    `,
+};
+
+// We use a picture element here with an empty image for < tablet so that we
+// don't load an image unnecessarily when we're not going to render it (which would be
+// the case with an img tag)
+const HeaderSection: React.FC = () => (
+    <div css={headerStyles.container}>
+        <div css={headerStyles.leftContainer}>
+            <span css={headerStyles.text}>You&#8217;re powering open, independent journalism</span>
+        </div>
+        <div css={headerStyles.rightContainer}>
+            <picture css={headerStyles.picture}>
+                <source srcSet={emptyImage} media={`(max-width: ${breakpoints.tablet - 1}px)`} />
+                <source srcSet={HEADER_IMAGE_URL} media={`(min-width: ${breakpoints.tablet}px)`} />
+                <img css={headerStyles.image} src={HEADER_IMAGE_URL} alt="" />
+            </picture>
+
+            <div css={headerStyles.imageCaptionContainer}>
+                <p css={[headerStyles.imageCaption, headerStyles.imageCaptionBold]}>
+                    Mark Rice-Oxley
+                </p>
+                <p css={[headerStyles.imageCaption, headerStyles.imageCaptionItalic]}>
+                    Executive Editor,
+                </p>
+                <p css={headerStyles.imageCaption}>Reader Revenues</p>
+            </div>
+        </div>
+    </div>
+);
+
+export const EpicWithSpecialHeader: React.FC<EpicProps> = (props: EpicProps) => (
+    <Epic {...props} headerSection={<HeaderSection />} />
+);

--- a/src/canRender.ts
+++ b/src/canRender.ts
@@ -14,7 +14,7 @@ import {
     COMPONENT_NAME as SPECIAL_EDITION_BANNER_NAME,
     canRender as specialEdCanRender,
 } from './SpecialEditionBanner/canRender';
-import { canRenderEpic } from './Epic/canRender';
+import { COMPONENT_NAME as EPIC_NAME, canRender as epicCanRender } from './Epic/canRender';
 import {
     COMPONENT_NAME as NEWSLETTER_EPIC_NAME,
     canRender as newsletterEpicCanRender,
@@ -35,6 +35,11 @@ import {
     canRender as ukNewsletterEpicCanRender,
 } from './UKNewsletterEpic/canRender';
 
+import {
+    COMPONENT_NAME as EPIC_WITH_IMAGE_NAME,
+    canRender as epicWithImageCanRender,
+} from './EpicWithSpecialHeader/canRender';
+
 /** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
  * this means the user won't download the Braze components bundle when the component can't be shown.
  */
@@ -49,11 +54,12 @@ const COMPONENT_CAN_RENDER_MAPPINGS: Record<
     [DIGITAL_SUBSCRIBER_APP_BANNER_NAME]: digitialSubCanRender,
     [SPECIAL_EDITION_BANNER_NAME]: specialEdCanRender,
     [THE_GUARDIAN_IN_2020_BANNER_NAME]: gIn2020BannerCanRender,
-    Epic: canRenderEpic,
+    [EPIC_NAME]: epicCanRender,
     [NEWSLETTER_EPIC_NAME]: newsletterEpicCanRender,
     [US_NEWSLETTER_EPIC_NAME]: usNewsletterEpicCanRender,
     [AU_NEWSLETTER_EPIC_NAME]: auNewsletterEpicCanRender,
     [UK_NEWSLETTER_EPIC_NAME]: ukNewsletterEpicCanRender,
+    [EPIC_WITH_IMAGE_NAME]: epicWithImageCanRender,
 };
 
 export const canRenderBrazeMsg = (msgExtras: Extras | undefined): boolean => {

--- a/src/storybookCommon/argTypes.ts
+++ b/src/storybookCommon/argTypes.ts
@@ -29,3 +29,22 @@ export const ophanComponentIdArgType = {
             '`rc_upsell_test1_variant`.',
     },
 };
+
+export const buildEpicParagraphDocs = (
+    numberOfParagraphs: number,
+): [string, Record<string, unknown>][] =>
+    Array.from({ length: numberOfParagraphs }, (_, idx) => {
+        const name = `paragraph${idx + 1}`;
+        return [
+            name,
+            {
+                name,
+                type: {
+                    name: 'string',
+                    required: idx === 0,
+                },
+                description:
+                    'Paragraph text. Supports HTML. If adding links see Braze user guide for tracking params.',
+            },
+        ];
+    });


### PR DESCRIPTION
## What does this change?

This PR adds a new component `EpicWithHeaderImage`. The new component is implemented on top of the existing Epic component and adds a new header section including a headshot and some additional text.

This PR supersedes #222. It turned out the image marketing wanted to use was very text heavy, which didn't feel like a great fit (accessibility concerns, as well as general inflexibility of delivering text in an image).

Note: The entire new top section is hidden on mobile.

We’re treating our first usage of the epic with an image as an experiment, so short term we’ll hardcode the text and image to avoid the overhead of adding proper image support (via the picker). If the test goes well we can make all this a properly supported part of the Epic component.

https://trello.com/c/xODg9J4r/1217-new-epic-template-with-image

## How to test

In Storybook, there's a new story EpicWithHeaderImage under WorkInProgress/EndOfArticle.

## How can we measure success?

We'll be running a test to validate this new feature.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![Screenshot 2021-09-14 at 15 15 34](https://user-images.githubusercontent.com/379839/133274387-aa02a157-434f-4aa0-abbc-4dfde611b02d.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
