### PR TITLE
Move EpicWithSpecialHeader out of work-in-progress

### DIFF
--- a/src/EpicWithSpecialHeader/index.stories.tsx
+++ b/src/EpicWithSpecialHeader/index.stories.tsx
@@ -14,7 +14,7 @@ const paragraphDocs = buildEpicParagraphDocs(NUMBER_OF_PARAGRAPHS);
 
 export default {
     component: 'EpicWithSpecialHeader',
-    title: 'WorkInProgress/EndOfArticle/EpicWithSpecialHeader',
+    title: 'EndOfArticle/EpicWithSpecialHeader',
     argTypes: {
         ...coreArgTypes,
         ...ophanComponentIdArgType,


### PR DESCRIPTION
## What does this change?

The version of braze-components which introduces `EpicWithSpecialHeader` is now being used by DCR, so we can take this out of work-in-progress.