### PR TITLE
Reduce TTL on cloudfront cache to 1 minute

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -38,7 +38,8 @@ Resources:
                 DefaultCacheBehavior:
                     AllowedMethods: [HEAD, GET]
                     CachedMethods: [HEAD, GET]
-                    MinTTL: 3600
+                    MinTTL: 60
+                    MaxTTL: 60
                     Compress: true
                     ForwardedValues:
                         QueryString: false


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Reduces the min (and now max) TTL for the cache on the cloudfront used to host braze-components.gutools.co.uk from 1 hour to 1 minute. This reduces the time it takes to confirm that a change is in production storybook which is really helpful when deploying hotfixes. 

https://trello.com/c/LVCDMM2l/1236-revisit-braze-componentsgutoolscouk-caching-strategy

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Make a change to braze components and check that it shows up in a few minutes as opposed to an hour. Also check the network tab for a changed cache control header.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Changes to braze components show up in a few minutes as opposed to an hour.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This will reduce the use of the cache slightly. Given this is an internal low traffic site the reduced cache hit's shouldn't be a problem.