### PR TITLE
Article context filtering (section only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/braze-components",
-  "version": "4.0.0",
+  "version": "4.1.0-0",
   "description": "React components to render messages from Braze",
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",

--- a/src/logic/BrazeMessages.test.ts
+++ b/src/logic/BrazeMessages.test.ts
@@ -1,6 +1,6 @@
 import appboy from '@braze/web-sdk-core';
 import { createNanoEvents, Emitter } from 'nanoevents';
-import { BrazeMessages } from './BrazeMessages';
+import { BrazeArticleContext, BrazeMessages } from './BrazeMessages';
 import { LocalMessageCache, InMemoryCache, hydrateMessage } from './LocalMessageCache';
 
 import { COMPONENT_NAME as G2020_BANNER_NAME } from '../TheGuardianIn2020Banner/canRender';
@@ -376,6 +376,33 @@ describe('BrazeMessages', () => {
                 const secondMessage = await brazeMessages.getMessageForEndOfArticle();
 
                 expect(firstMessage).toEqual(secondMessage);
+            });
+
+            it('prioritises a message with matching page context filters', async () => {
+                const messageWithoutFilter = buildMessage(JSON.parse(message1Json));
+                InMemoryCache.push('EndOfArticle', {
+                    message: messageWithoutFilter,
+                    id: '1',
+                });
+                const messageWithFilter = buildMessage(JSON.parse(message1Json));
+                messageWithFilter.extras.section = 'environment';
+                InMemoryCache.push('EndOfArticle', {
+                    message: messageWithFilter,
+                    id: '2',
+                });
+                const fakeAppBoy = new FakeAppBoy();
+                const brazeMessages = new BrazeMessages(
+                    fakeAppBoy as unknown as typeof appboy,
+                    InMemoryCache,
+                    (error, identifier) => console.log(identifier, error),
+                );
+                const articleContext: BrazeArticleContext = {
+                    section: 'environment',
+                };
+
+                const gotMessage = await brazeMessages.getMessageForEndOfArticle(articleContext);
+
+                expect(gotMessage.message).toEqual(messageWithFilter);
             });
         });
     });

--- a/src/logic/BrazeMessages.tsx
+++ b/src/logic/BrazeMessages.tsx
@@ -188,8 +188,10 @@ class BrazeMessages implements BrazeMessagesInterface {
             .concat(messagesWithoutFilters)
             .filter((msg) => {
                 return (
-                    msg.message.extras.section === articleContext?.section ||
-                    !msg.message.extras.section
+                    !msg.message.extras.section ||
+                    typeof msg.message.extras.section != 'string' ||
+                    msg.message.extras.section.toLowerCase() ===
+                        articleContext?.section?.toLowerCase()
                 );
             });
 

--- a/src/logic/LocalMessageCache.tsx
+++ b/src/logic/LocalMessageCache.tsx
@@ -8,7 +8,7 @@ export const millisecondsBeforeExpiry = 1000 * 60 * 60 * 24; // 24 hours: 60 sec
 
 type Message = appboy.InAppMessage;
 
-type MessageWithId = {
+export type MessageWithId = {
     id: string;
     message: Message;
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
https://trello.com/c/d5NYSNVi/1250-update-guardian-braze-components-to-filter-by-section
Adds article context filtering (worked on by Tom Wey as part of team hack day) to the braze components message cache. When we receive a message from Braze that should trigger a component being displayed on the page we store in in a local storage cache. With this change we only show messages from the cache if they match the article context (otherwise they stay in the cache).

For example if the braze message has the field section with value 'environment' the message will only be shown on articles in the environment section.

The only change here from the hack day code is an interface called BrazeArticleContext is passed to the braze cache logic instead of the section directly. This is to support more article context fields in future.

DCR PR: https://github.com/guardian/dotcom-rendering/pull/3503

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
