### PR TITLE
Fix type annotations

### DIFF
--- a/src/logic/BrazeMessages.test.ts
+++ b/src/logic/BrazeMessages.test.ts
@@ -1,7 +1,7 @@
 import appboy from '@braze/web-sdk-core';
 import { createNanoEvents, Emitter } from 'nanoevents';
 import { BrazeArticleContext, BrazeMessages } from './BrazeMessages';
-import { LocalMessageCache, InMemoryCache, hydrateMessage } from './LocalMessageCache';
+import { LocalMessageCache, hydrateMessage, MessageData } from './LocalMessageCache';
 
 import { COMPONENT_NAME as BANNER_WITH_LINK_NAME } from '../BannerWithLink/canRender';
 
@@ -61,7 +61,7 @@ beforeEach(() => {
     logInAppMessageImpressionSpy.mockClear();
 });
 
-const buildMessage = (data: Record<string, unknown>) => hydrateMessage(data, appboy);
+const buildMessage = (data: MessageData) => hydrateMessage(data, appboy);
 
 describe('BrazeMessages', () => {
     describe(`When the cache is enabled`, () => {
@@ -245,160 +245,31 @@ describe('BrazeMessages', () => {
 
                 expect(firstMessage).toEqual(secondMessage);
             });
-        });
-    });
-
-    describe(`When the cache is not enabled`, () => {
-        beforeEach(() => {
-            InMemoryCache.clear();
-        });
-        describe('getMessageForBanner & getMessageForEndOfArticle', () => {
-            it('returns a promise which resolves with message data for the correct slot', async () => {
-                const fakeAppBoy = new FakeAppBoy();
-                const brazeMessages = new BrazeMessages(
-                    fakeAppBoy as unknown as typeof appboy,
-                    InMemoryCache,
-                    (error, identifier) => console.log(identifier, error),
-                );
-
-                const bannerPromise = brazeMessages.getMessageForBanner();
-                const endOfArticlePromise = brazeMessages.getMessageForEndOfArticle();
-
-                const bannerMessage = buildMessage({
-                    extras: bannerExtras,
-                });
-                fakeAppBoy.emit(bannerMessage);
-
-                const endOfArticleMessage = buildMessage({
-                    extras: epicExtras,
-                });
-                fakeAppBoy.emit(endOfArticleMessage);
-
-                const data = await Promise.all([bannerPromise, endOfArticlePromise]);
-                expect(data[0].extras).toEqual(bannerMessage.extras);
-                expect(data[1].extras).toEqual(endOfArticleMessage.extras);
-            });
-
-            it('returns a message which is capable of logging an impression', async () => {
-                const fakeAppBoy = new FakeAppBoy();
-                const brazeMessages = new BrazeMessages(
-                    fakeAppBoy as unknown as typeof appboy,
-                    InMemoryCache,
-                    (error, identifier) => console.log(identifier, error),
-                );
-
-                const bannerPromise = brazeMessages.getMessageForBanner();
-
-                const message = buildMessage({
-                    extras: bannerExtras,
-                });
-                fakeAppBoy.emit(message);
-
-                const bannerMessage = await bannerPromise;
-                bannerMessage.logImpression();
-
-                expect(logInAppMessageImpressionSpy).toHaveBeenCalledWith(message);
-            });
-
-            it('returns a message with an id', async () => {
-                const fakeAppBoy = new FakeAppBoy();
-                const brazeMessages = new BrazeMessages(
-                    fakeAppBoy as unknown as typeof appboy,
-                    InMemoryCache,
-                    (error, identifier) => console.log(identifier, error),
-                );
-
-                const bannerPromise = brazeMessages.getMessageForBanner();
-
-                const message = buildMessage({
-                    extras: bannerExtras,
-                });
-                fakeAppBoy.emit(message);
-
-                const bannerMessage = await bannerPromise;
-
-                expect(bannerMessage.id).toMatch(/\w{11,13}-\d{13}/);
-            });
-
-            it('returns a cached message if one is available', async () => {
-                const cachedMessage = buildMessage(JSON.parse(message1Json));
-                InMemoryCache.push('EndOfArticle', {
-                    message: cachedMessage,
-                    id: '1',
-                });
-                const freshMessage = buildMessage(JSON.parse(message2Json));
-                const fakeAppBoy = new FakeAppBoy();
-                const brazeMessages = new BrazeMessages(
-                    fakeAppBoy as unknown as typeof appboy,
-                    InMemoryCache,
-                    (error, identifier) => console.log(identifier, error),
-                );
-                fakeAppBoy.emit(freshMessage);
-
-                const gotMessage = await brazeMessages.getMessageForEndOfArticle();
-
-                expect(gotMessage.message).toEqual(cachedMessage);
-            });
-
-            it('logging an impression results in the message being removed from the cache', async () => {
-                const cachedMessage = buildMessage(JSON.parse(message1Json));
-                InMemoryCache.push('EndOfArticle', {
-                    message: cachedMessage,
-                    id: '1',
-                });
-                const freshMessage = buildMessage(JSON.parse(message2Json));
-                const fakeAppBoy = new FakeAppBoy();
-                const brazeMessages = new BrazeMessages(
-                    fakeAppBoy as unknown as typeof appboy,
-                    InMemoryCache,
-                    (error, identifier) => console.log(identifier, error),
-                );
-                fakeAppBoy.emit(freshMessage);
-
-                const firstMessage = await brazeMessages.getMessageForEndOfArticle();
-                firstMessage.logImpression();
-
-                const anotherMessage = await brazeMessages.getMessageForEndOfArticle();
-                expect(anotherMessage.message).toEqual(freshMessage);
-            });
-
-            it('returns the same cached message multiple times if an impression is not logged', async () => {
-                const cachedMessage = buildMessage(JSON.parse(message1Json));
-                InMemoryCache.push('EndOfArticle', {
-                    message: cachedMessage,
-                    id: '1',
-                });
-                const freshMessage = buildMessage(JSON.parse(message2Json));
-                const fakeAppBoy = new FakeAppBoy();
-                const brazeMessages = new BrazeMessages(
-                    fakeAppBoy as unknown as typeof appboy,
-                    InMemoryCache,
-                    (error, identifier) => console.log(identifier, error),
-                );
-                fakeAppBoy.emit(freshMessage);
-
-                const firstMessage = await brazeMessages.getMessageForEndOfArticle();
-                const secondMessage = await brazeMessages.getMessageForEndOfArticle();
-
-                expect(firstMessage).toEqual(secondMessage);
-            });
 
             it('prioritises a message with matching page context filters', async () => {
                 const messageWithoutFilter = buildMessage(JSON.parse(message1Json));
-                InMemoryCache.push('EndOfArticle', {
-                    message: messageWithoutFilter,
-                    id: '1',
-                });
+                LocalMessageCache.push(
+                    'EndOfArticle',
+                    {
+                        message: messageWithoutFilter,
+                        id: '1',
+                    },
+                    (e) => console.log(e),
+                );
                 const messageWithFilter = buildMessage(JSON.parse(message1Json));
                 messageWithFilter.extras.section = 'environment';
-                InMemoryCache.push('EndOfArticle', {
-                    message: messageWithFilter,
-                    id: '2',
-                });
+                LocalMessageCache.push(
+                    'EndOfArticle',
+                    {
+                        message: messageWithFilter,
+                        id: '2',
+                    },
+                    (e) => console.log(e),
+                );
                 const fakeAppBoy = new FakeAppBoy();
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
-                    InMemoryCache,
+                    LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
                 );
                 const articleContext: BrazeArticleContext = {

--- a/src/logic/BrazeMessages.tsx
+++ b/src/logic/BrazeMessages.tsx
@@ -32,7 +32,7 @@ class BrazeMessage {
 
     appboy: typeof appboy;
 
-    message: appboy.InAppMessage;
+    message: appboy.HtmlMessage;
 
     slotName: SlotName;
 
@@ -42,7 +42,7 @@ class BrazeMessage {
 
     constructor(
         id: string,
-        message: appboy.InAppMessage,
+        message: appboy.HtmlMessage,
         appboyInstance: typeof appboy,
         slotName: SlotName,
         cache: MessageCache,
@@ -91,7 +91,7 @@ class BrazeMessage {
 class BrazeMessages implements BrazeMessagesInterface {
     appboy: typeof appboy;
 
-    freshMessageBySlot: Record<SlotName, Promise<appboy.InAppMessage>>;
+    freshMessageBySlot: Record<SlotName, Promise<appboy.HtmlMessage>>;
 
     cache: MessageCache;
 
@@ -109,11 +109,11 @@ class BrazeMessages implements BrazeMessagesInterface {
 
     // Generally we only expect a single message per slot max in a pageview. This method
     // returns a promise which will resolve when the first message arrives
-    private getFreshMessagesForSlot(targetSlotName: SlotName): Promise<appboy.InAppMessage> {
+    private getFreshMessagesForSlot(targetSlotName: SlotName): Promise<appboy.HtmlMessage> {
         return new Promise((resolve) => {
             const callback = (m: appboy.InAppMessage | appboy.ControlMessage) => {
-                // Cast this as we only ever expect it to be an InAppMessage
-                const message = m as appboy.InAppMessage;
+                // Cast this as we only ever expect it to be an HtmlMessage (subclass of InAppMessage)
+                const message = m as appboy.HtmlMessage;
                 const { extras } = message;
 
                 if (extras && extras.slotName && extras.slotName === targetSlotName) {

--- a/src/logic/LocalMessageCache.test.ts
+++ b/src/logic/LocalMessageCache.test.ts
@@ -1,13 +1,19 @@
 import appboy from '@braze/web-sdk-core';
 import { storage } from '@guardian/libs';
-import { LocalMessageCache, CachedMessage, setQueue, hydrateMessage } from './LocalMessageCache';
+import {
+    LocalMessageCache,
+    CachedMessage,
+    setQueue,
+    hydrateMessage,
+    MessageData,
+} from './LocalMessageCache';
 import type { SlotName } from './types';
 
 const message1Json = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 1","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
 const message2Json = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 2","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
 const message3Json = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 3","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
 
-type Message = appboy.InAppMessage;
+type Message = appboy.HtmlMessage;
 
 beforeEach(() => {
     storage.local.clear();
@@ -33,7 +39,7 @@ const anHourFromNow = () => {
 const buildUnexpiredMessage = (message: Message, id: string): CachedMessage => ({
     message: {
         id,
-        message,
+        message: message as MessageData,
     },
     expires: anHourFromNow(),
 });
@@ -41,7 +47,7 @@ const buildUnexpiredMessage = (message: Message, id: string): CachedMessage => (
 const buildExpiredMessage = (message: Message, id: string): CachedMessage => ({
     message: {
         id,
-        message,
+        message: message as MessageData,
     },
     expires: anHourAgo(),
 });


### PR DESCRIPTION
## What does this change?

ESLint was complaining about a couple of uses of `any`, this PR removes them to replace with more meaningful types.

As part of making this change, I removed the (now unused) `InMemoryCache`, which we replaced with the local storage backed cache a while back.

## How to test

`yarn lint && yarn tsc`

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
