### PR TITLE
Down to earth newsletter epic

### DIFF
--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -38,7 +38,7 @@ const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps
     [UK_NEWSLETTER_EPIC_NAME]: UKNewsletterEpic,
     [EPIC_NAME]: Epic,
     [EPIC_WITH_HEADER_IMAGE_NAME]: EpicWithSpecialHeader,
-    [DTO_NEWSLETTER_EPIC_NAME]: DownToEarthNewsletterEpic,
+    [DTE_NEWSLETTER_EPIC_NAME]: DownToEarthNewsletterEpic,
 };
 
 export const BrazeEndOfArticleComponent: React.FC<CommonEndOfArticleComponentProps> =

--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -9,6 +9,10 @@ import {
 import { COMPONENT_NAME as US_NEWSLETTER_EPIC_NAME, USNewsletterEpic } from './USNewsletterEpic';
 import { COMPONENT_NAME as AU_NEWSLETTER_EPIC_NAME, AUNewsletterEpic } from './AUNewsletterEpic';
 import { COMPONENT_NAME as UK_NEWSLETTER_EPIC_NAME, UKNewsletterEpic } from './UKNewsletterEpic';
+import {
+    COMPONENT_NAME as DTO_NEWSLETTER_EPIC_NAME,
+    DownToEarthNewsletterEpic,
+} from './DownToEarthNewsletterEpic';
 import { COMPONENT_NAME as EPIC_NAME, Epic } from './Epic';
 import {
     COMPONENT_NAME as EPIC_WITH_HEADER_IMAGE_NAME,
@@ -34,6 +38,7 @@ const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps
     [UK_NEWSLETTER_EPIC_NAME]: UKNewsletterEpic,
     [EPIC_NAME]: Epic,
     [EPIC_WITH_HEADER_IMAGE_NAME]: EpicWithSpecialHeader,
+    [DTO_NEWSLETTER_EPIC_NAME]: DownToEarthNewsletterEpic,
 };
 
 export const BrazeEndOfArticleComponent: React.FC<CommonEndOfArticleComponentProps> =

--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -10,7 +10,7 @@ import { COMPONENT_NAME as US_NEWSLETTER_EPIC_NAME, USNewsletterEpic } from './U
 import { COMPONENT_NAME as AU_NEWSLETTER_EPIC_NAME, AUNewsletterEpic } from './AUNewsletterEpic';
 import { COMPONENT_NAME as UK_NEWSLETTER_EPIC_NAME, UKNewsletterEpic } from './UKNewsletterEpic';
 import {
-    COMPONENT_NAME as DTO_NEWSLETTER_EPIC_NAME,
+    COMPONENT_NAME as DTE_NEWSLETTER_EPIC_NAME,
     DownToEarthNewsletterEpic,
 } from './DownToEarthNewsletterEpic';
 import { COMPONENT_NAME as EPIC_NAME, Epic } from './Epic';

--- a/src/DownToEarthNewsletterEpic/canRender.ts
+++ b/src/DownToEarthNewsletterEpic/canRender.ts
@@ -1,0 +1,9 @@
+import { BrazeMessageProps } from '../DownToEarthNewsletterEpic';
+
+export const COMPONENT_NAME = 'DownToEarthNewsletterEpic';
+
+export const canRender = (props: BrazeMessageProps): boolean => {
+    const { header, frequency, paragraph1, ophanComponentId } = props;
+
+    return Boolean(header && frequency && paragraph1 && ophanComponentId);
+};

--- a/src/DownToEarthNewsletterEpic/index.stories.tsx
+++ b/src/DownToEarthNewsletterEpic/index.stories.tsx
@@ -1,0 +1,83 @@
+import React, { ReactElement } from 'react';
+import { BrazeEndOfArticleComponent } from '../BrazeEndOfArticleComponent';
+import { StorybookWrapper } from '../utils/StorybookWrapper';
+import { knobsData } from '../utils/knobsData';
+import { coreArgTypes, ophanComponentIdArgType } from '../storybookCommon/argTypes';
+import type { BrazeMessageProps } from '.';
+
+export default {
+    component: 'DownToEarthNewsletterEpic',
+    title: 'EndOfArticle/DownToEarthNewsletterEpic',
+    parameters: {
+        articleContext: {
+            disable: false,
+        },
+    },
+    argTypes: {
+        ...coreArgTypes,
+        ...ophanComponentIdArgType,
+        header: {
+            name: 'header',
+            type: { name: 'string', required: true },
+            description: 'Header text',
+        },
+        frequency: {
+            name: 'frequency',
+            type: { name: 'string', required: true },
+            description: 'Text description of how often the email is sent',
+        },
+        paragraph1: {
+            name: 'paragraph1',
+            type: { name: 'string', required: true },
+            description: 'First paragraph',
+        },
+        paragraph2: {
+            name: 'paragraph2',
+            type: { name: 'string', required: false },
+            description: 'Second paragraph',
+        },
+    },
+};
+
+const StoryTemplate = (
+    args: BrazeMessageProps & { componentName: string },
+): ReactElement | null => {
+    const brazeMessageProps = {
+        header: args.header,
+        frequency: args.frequency,
+        paragraph1: args.paragraph1,
+        paragraph2: args.paragraph2,
+        ophanComponentId: args.ophanComponentId,
+    };
+
+    knobsData.set({ ...brazeMessageProps, componentName: args.componentName });
+
+    return (
+        <StorybookWrapper>
+            <BrazeEndOfArticleComponent
+                componentName={args.componentName}
+                brazeMessageProps={brazeMessageProps}
+                subscribeToNewsletter={(newsletterId) => {
+                    console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
+                    return new Promise((resolve) => setTimeout(() => resolve(), 1000));
+                }}
+            />
+        </StorybookWrapper>
+    );
+};
+
+export const DefaultStory = StoryTemplate.bind({});
+
+DefaultStory.args = {
+    slotName: 'EndOfArticle',
+    header: 'Down To Earth',
+    frequency: 'Weekly',
+    paragraph1:
+        'An exclusive weekly piece from our top climate crisis correspondents, as well as a digest of the biggest environment stories – plus the good news, the not-so-good news, and everything else you need to know.',
+    paragraph2:
+        'We thought you should know this newsletter may contain information about Guardian products and services.',
+    componentName: 'DownToEarthNewsletterEpic',
+    ophanComponentId: 'example_ophan_component_id',
+};
+
+DefaultStory.storyName = 'DownToEarthNewsletterEpic';

--- a/src/DownToEarthNewsletterEpic/index.tsx
+++ b/src/DownToEarthNewsletterEpic/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { canRender, COMPONENT_NAME } from './canRender';
+import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
+
+const newsletterId = '4147';
+
+const IMAGE_URL =
+    'https://i.guim.co.uk/img/media/591152b12591385d278b2c112d31a561a40a2e2d/0_1_648_648/648.png?width=196&s=be117e8d22a0c389daf49b369f726915';
+
+export type BrazeMessageProps = {
+    header?: string;
+    frequency?: string;
+    paragraph1?: string;
+    paragraph2?: string;
+    ophanComponentId?: string;
+};
+
+export type Props = {
+    brazeMessageProps: BrazeMessageProps;
+    subscribeToNewsletter: NewsletterSubscribeCallback;
+};
+
+export const DownToEarthNewsletterEpic: React.FC<Props> = (props: Props) => {
+    if (!canRender(props.brazeMessageProps)) {
+        return null;
+    }
+
+    return (
+        <NewsletterEpic
+            {...props}
+            brazeMessageProps={{ ...props.brazeMessageProps, imageUrl: IMAGE_URL, newsletterId }}
+        ></NewsletterEpic>
+    );
+};
+
+export { COMPONENT_NAME };

--- a/src/canRender.ts
+++ b/src/canRender.ts
@@ -41,8 +41,8 @@ import {
 } from './EpicWithSpecialHeader/canRender';
 
 import {
-    COMPONENT_NAME as DTO_NEWSLETTER_EPIC_NAME,
-    canRender as dtoNewsletterEpicCanRender,
+    COMPONENT_NAME as DTE_NEWSLETTER_EPIC_NAME,
+    canRender as dteNewsletterEpicCanRender,
 } from './DownToEarthNewsletterEpic/canRender';
 
 /** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
@@ -65,7 +65,7 @@ const COMPONENT_CAN_RENDER_MAPPINGS: Record<
     [AU_NEWSLETTER_EPIC_NAME]: auNewsletterEpicCanRender,
     [UK_NEWSLETTER_EPIC_NAME]: ukNewsletterEpicCanRender,
     [EPIC_WITH_IMAGE_NAME]: epicWithImageCanRender,
-    [DTO_NEWSLETTER_EPIC_NAME]: dtoNewsletterEpicCanRender,
+    [DTE_NEWSLETTER_EPIC_NAME]: dteNewsletterEpicCanRender,
 };
 
 export const canRenderBrazeMsg = (msgExtras: Extras | undefined): boolean => {

--- a/src/canRender.ts
+++ b/src/canRender.ts
@@ -40,6 +40,11 @@ import {
     canRender as epicWithImageCanRender,
 } from './EpicWithSpecialHeader/canRender';
 
+import {
+    COMPONENT_NAME as DTO_NEWSLETTER_EPIC_NAME,
+    canRender as dtoNewsletterEpicCanRender,
+} from './DownToEarthNewsletterEpic/canRender';
+
 /** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
  * this means the user won't download the Braze components bundle when the component can't be shown.
  */
@@ -60,6 +65,7 @@ const COMPONENT_CAN_RENDER_MAPPINGS: Record<
     [AU_NEWSLETTER_EPIC_NAME]: auNewsletterEpicCanRender,
     [UK_NEWSLETTER_EPIC_NAME]: ukNewsletterEpicCanRender,
     [EPIC_WITH_IMAGE_NAME]: epicWithImageCanRender,
+    [DTO_NEWSLETTER_EPIC_NAME]: dtoNewsletterEpicCanRender,
 };
 
 export const canRenderBrazeMsg = (msgExtras: Extras | undefined): boolean => {


### PR DESCRIPTION
## What does this change?

Adds the down to earth newsletter epic component
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

https://braze-components.code.dev-gutools.co.uk/?path=/story/endofarticle-downtoearthnewsletterepic--default-story
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![Screenshot 2021-11-03 at 18 18 54](https://user-images.githubusercontent.com/3285072/140499788-de49c40c-13d7-482d-8eb3-503a69f3d11c.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
