### PR TITLE
Create new Cloudfront Distribution in CDK

### DIFF
--- a/cdk/lib/__snapshots__/braze-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/braze-components.test.ts.snap
@@ -207,6 +207,85 @@ Object {
       },
       "Type": "Guardian::DNS::RecordSet",
     },
+    "brazecomponentscloudfrontCFDistributionCD76C2A5": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "DefaultCacheBehavior": Object {
+            "AllowedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "CachedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "Compress": true,
+            "ForwardedValues": Object {
+              "Cookies": Object {
+                "Forward": "none",
+              },
+              "QueryString": false,
+            },
+            "TargetOriginId": "origin1",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "ConnectionAttempts": 3,
+              "ConnectionTimeout": 10,
+              "DomainName": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "braze-components-storybook.s3.",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ".",
+                    Object {
+                      "Ref": "AWS::URLSuffix",
+                    },
+                  ],
+                ],
+              },
+              "Id": "origin1",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": "origin-access-identity/cloudfront/E3EA9DC41190PP",
+              },
+            },
+          ],
+          "PriceClass": "PriceClass_100",
+          "ViewerCertificate": Object {
+            "CloudFrontDefaultCertificate": true,
+          },
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/braze-components",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "targeting",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
   },
 }
 `;

--- a/cdk/lib/__snapshots__/braze-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/braze-components.test.ts.snap
@@ -253,6 +253,17 @@ Object {
                 ],
               },
               "Id": "origin1",
+              "OriginPath": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/braze-components-storybook-static",
+                  ],
+                ],
+              },
               "S3OriginConfig": Object {
                 "OriginAccessIdentity": "origin-access-identity/cloudfront/E3EA9DC41190PP",
               },

--- a/cdk/lib/__snapshots__/braze-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/braze-components.test.ts.snap
@@ -257,6 +257,7 @@ Object {
                 "Fn::Join": Array [
                   "",
                   Array [
+                    "/",
                     Object {
                       "Ref": "Stage",
                     },

--- a/cdk/lib/braze-components.ts
+++ b/cdk/lib/braze-components.ts
@@ -52,7 +52,7 @@ export class BrazeComponents extends GuStack {
                     s3OriginSource: {
                         s3BucketSource: sourceBucket,
                         originAccessIdentity,
-                        originPath: `${this.stage}/braze-components-storybook-static`,
+                        originPath: `/${this.stage}/braze-components-storybook-static`,
                     },
                     behaviors: [{ isDefaultBehavior: true }],
                 },

--- a/cdk/lib/braze-components.ts
+++ b/cdk/lib/braze-components.ts
@@ -1,5 +1,7 @@
 import { join } from 'path';
 import type { CfnDistribution } from '@aws-cdk/aws-cloudfront';
+import { CloudFrontWebDistribution, OriginAccessIdentity } from '@aws-cdk/aws-cloudfront';
+import { Bucket } from '@aws-cdk/aws-s3';
 import { CfnInclude } from '@aws-cdk/cloudformation-include';
 import type { App } from '@aws-cdk/core';
 import { Duration } from '@aws-cdk/core';
@@ -28,6 +30,32 @@ export class BrazeComponents extends GuStack {
             },
             resourceRecord: oldCloudfrontDist.getAtt('DomainName').toString(),
             ttl: Duration.hours(1),
+        });
+
+        const bucketNameFromStaticCloudformationStack = 'braze-components-storybook';
+        const sourceBucket = Bucket.fromBucketName(
+            this,
+            'braze-components-bucket',
+            bucketNameFromStaticCloudformationStack,
+        );
+
+        const originAccessIdFromStaticCloudformationStack = 'E3EA9DC41190PP';
+        const originAccessIdentity = OriginAccessIdentity.fromOriginAccessIdentityName(
+            this,
+            'braze-components-origin-access-identity',
+            originAccessIdFromStaticCloudformationStack,
+        );
+
+        new CloudFrontWebDistribution(this, 'braze-components-cloudfront', {
+            originConfigs: [
+                {
+                    s3OriginSource: {
+                        s3BucketSource: sourceBucket,
+                        originAccessIdentity,
+                    },
+                    behaviors: [{ isDefaultBehavior: true }],
+                },
+            ],
         });
     }
 }

--- a/cdk/lib/braze-components.ts
+++ b/cdk/lib/braze-components.ts
@@ -52,6 +52,7 @@ export class BrazeComponents extends GuStack {
                     s3OriginSource: {
                         s3BucketSource: sourceBucket,
                         originAccessIdentity,
+                        originPath: `${this.stage}/braze-components-storybook-static`,
                     },
                     behaviors: [{ isDefaultBehavior: true }],
                 },

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@aws-cdk/cloudformation-include": "1.132.0",
     "@aws-cdk/core": "1.132.0",
+    "@aws-cdk/aws-s3": "1.132.0",
     "@guardian/cdk": "31.4.0",
     "source-map-support": "^0.5.20"
   }


### PR DESCRIPTION
## What does this change?

Create a Cloudfront Distribution in our CDK, wiring it up with the existing static bucket and access origin ID.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Deploy via Riff Raff and visit the Cloudfront URL.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
