### PR TITLE
BannerWithLink style tweaks

### DIFF
--- a/src/BannerWithLink/index.stories.tsx
+++ b/src/BannerWithLink/index.stories.tsx
@@ -54,7 +54,7 @@ export default {
 
 const StoryTemplate = (args: BrazeMessageProps & { componentName: string }): ReactElement => {
     const imageUrl = grid(
-        'https://i.guim.co.uk/img/media/c9ba78ef2b1a931aab5ca625ce49646e116b11b3/0_0_3200_1800/3200.png?quality=60&width=930&s=72ff133ea3e4516f5a353213e7a62e8a',
+        'https://i.guim.co.uk/img/media/3bf8e0a7b3d59ba66ac91792ceed73a7b0536f62/0_0_931_523/master/931.png?width=930&quality=45&auto=format&s=629e348cc332f79b8ae9beda5c3f3429',
     );
 
     const brazeMessageProps: BrazeMessageProps = {

--- a/src/BannerWithLink/index.tsx
+++ b/src/BannerWithLink/index.tsx
@@ -2,16 +2,16 @@ import React, { useState } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import {
     Button,
-    buttonThemeReaderRevenueBrandAlt,
     LinkButton,
     SvgCross,
     SvgInfo,
+    buttonThemeReaderRevenueBrandAlt,
 } from '@guardian/source-react-components';
 import { OphanComponentEvent } from '@guardian/libs';
 
 import { BrazeClickHandler } from '../utils/tracking';
 import { styles as commonStyles } from '../styles/bannerCommon';
-import { styles } from './styles';
+import { overridenReaderRevenueTheme, styles } from './styles';
 import { canRender, COMPONENT_NAME } from './canRender';
 export { COMPONENT_NAME };
 
@@ -24,7 +24,6 @@ export type BrazeMessageProps = {
     buttonUrl?: string;
     imageUrl?: string;
 };
-import type { ButtonTheme } from '@guardian/source-react-components';
 
 export type Props = {
     logButtonClickWithBraze: BrazeClickHandler;
@@ -98,26 +97,15 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
         logToBrazeAndOphan(internalButtonId);
     };
 
-    // This is to keep button colors the same as before
-    // https://github.com/guardian/braze-components/pull/123
-    // Probably should be removed later
-    const overrridenReaderRevenueTheme: { button: ButtonTheme } = {
-        button: {
-            ...buttonThemeReaderRevenueBrandAlt.button,
-            backgroundPrimary: 'rgb(51, 51, 51)',
-            backgroundPrimaryHover: 'black',
-        },
-    };
-
     return (
-        <div css={commonStyles.wrapper}>
+        <div css={[commonStyles.wrapper, styles.wrapper]}>
             <div css={commonStyles.contentContainer}>
                 <div css={commonStyles.topLeftComponent}>
-                    <div css={commonStyles.infoIcon}>
+                    <div css={[commonStyles.infoIcon, styles.infoIcon]}>
                         <SvgInfo />
                     </div>
-                    <div css={commonStyles.heading}>
-                        <span css={commonStyles.smallInfoIcon}>
+                    <div css={[commonStyles.heading, styles.heading]}>
+                        <span css={[commonStyles.smallInfoIcon, styles.infoIcon]}>
                             <SvgInfo />
                         </span>
                         {header}
@@ -132,7 +120,7 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
                             </>
                         ) : null}
                     </p>
-                    <ThemeProvider theme={overrridenReaderRevenueTheme}>
+                    <ThemeProvider theme={overridenReaderRevenueTheme}>
                         <LinkButton
                             href={buttonUrl}
                             css={commonStyles.primaryButton}
@@ -151,7 +139,7 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
                             <Button
                                 icon={<SvgCross />}
                                 hideLabel={true}
-                                css={commonStyles.closeButton}
+                                cssOverrides={[commonStyles.closeButton, styles.closeButton]}
                                 priority="tertiary"
                                 size="small"
                                 aria-label="Close"

--- a/src/BannerWithLink/index.tsx
+++ b/src/BannerWithLink/index.tsx
@@ -122,13 +122,13 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
                         </span>
                         {header}
                     </div>
-                    <p css={styles.paragraph}>
+                    <p css={[commonStyles.paragraph, styles.paragraph]}>
                         {body}
 
                         {boldText ? (
                             <>
                                 <br />
-                                <strong css={styles.cta}>{boldText}</strong>
+                                <strong css={[commonStyles.cta, styles.cta]}>{boldText}</strong>
                             </>
                         ) : null}
                     </p>

--- a/src/BannerWithLink/styles.ts
+++ b/src/BannerWithLink/styles.ts
@@ -1,7 +1,5 @@
 import { css } from '@emotion/react';
-import { from, until, body, neutral, space } from '@guardian/source-foundations';
-
-const bodyColor = '#666';
+import { from, until, space } from '@guardian/source-foundations';
 
 export const styles = {
     image: css`
@@ -28,22 +26,10 @@ export const styles = {
         }
     `,
     paragraph: css`
-        ${body.medium()}
         font-size: 16px;
-        line-height: 135%;
-        margin: ${space[5]}px 0 ${space[5]}px;
-        max-width: 100%;
-        color: ${bodyColor};
-
-        ${from.phablet} {
-            max-width: 90%;
-        }
-
-        ${from.tablet} {
-            max-width: 100%;
-        }
 
         ${from.desktop} {
+            font-size: 16px;
             margin: ${space[3]}px 0 ${space[4]}px;
             max-width: 42rem;
         }
@@ -52,16 +38,8 @@ export const styles = {
             font-size: 20px;
             max-width: 37rem;
         }
-
-        ${from.wide} {
-            max-width: 42rem;
-        }
     `,
     cta: css`
-        font-weight: 700;
         margin-top: ${space[3]}px;
-        margin-right: ${space[3]}px;
-        display: inline-block;
-        color: ${neutral[20]};
     `,
 };

--- a/src/BannerWithLink/styles.ts
+++ b/src/BannerWithLink/styles.ts
@@ -1,7 +1,14 @@
 import { css } from '@emotion/react';
-import { from, until, space } from '@guardian/source-foundations';
+import { from, until, space, neutral } from '@guardian/source-foundations';
+import { ButtonTheme, buttonThemeReaderRevenueBrandAlt } from '@guardian/source-react-components';
+
+const backgroundColor = '#f79e1b';
+const buttonColor = '#007abc';
 
 export const styles = {
+    wrapper: css`
+        background-color: ${backgroundColor};
+    `,
     image: css`
         max-width: 100%;
         max-height: 260px;
@@ -27,6 +34,7 @@ export const styles = {
     `,
     paragraph: css`
         font-size: 16px;
+        color: ${neutral[0]};
 
         ${from.desktop} {
             font-size: 16px;
@@ -40,6 +48,30 @@ export const styles = {
         }
     `,
     cta: css`
+        color: ${neutral[0]};
         margin-top: ${space[3]}px;
     `,
+    closeButton: css`
+        &:hover {
+            background-color: transparent;
+        }
+    `,
+    infoIcon: css`
+        svg {
+            fill: ${neutral[0]};
+            background: transparent;
+        }
+    `,
+    heading: css`
+        color: ${neutral[0]};
+    `,
+};
+
+// Use this theme but override the colours to match the moment colours
+export const overridenReaderRevenueTheme: { button: ButtonTheme } = {
+    button: {
+        ...buttonThemeReaderRevenueBrandAlt.button,
+        backgroundPrimary: buttonColor,
+        backgroundPrimaryHover: buttonColor,
+    },
 };


### PR DESCRIPTION
## What does this change?

This PR updates the `BannerWithLink` colours to the designs from marketing for the Gu in 2021 moment.

I made a couple of simplifications along the way to accommodate the new colours, for example:

* Removed the hover effect on the close button and main link button
* Simplified the info icon to be a single colour with transparent background

## How to test

The changes are deployed to the [CODE storybook](https://braze-components.code.dev-gutools.co.uk/?path=/story/workinprogress-banner-bannerwithlink--default-story).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1552" alt="Screenshot 2022-01-17 at 12 10 30" src="https://user-images.githubusercontent.com/379839/149767354-30cc6c61-eac0-41de-a4ee-61c76211ab29.png">

<img width="612" alt="Screenshot 2022-01-17 at 12 11 34" src="https://user-images.githubusercontent.com/379839/149767447-067b9b95-db12-4f41-8102-65d3a8fa1adf.png">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [x] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
