### PR TITLE
BannerWithLink image tweaks

### DIFF
--- a/src/BannerWithLink/index.stories.tsx
+++ b/src/BannerWithLink/index.stories.tsx
@@ -54,7 +54,7 @@ export default {
 
 const StoryTemplate = (args: BrazeMessageProps & { componentName: string }): ReactElement => {
     const imageUrl = grid(
-        'https://i.guim.co.uk/img/media/3bf8e0a7b3d59ba66ac91792ceed73a7b0536f62/0_0_931_523/master/931.png?width=930&quality=45&auto=format&s=629e348cc332f79b8ae9beda5c3f3429',
+        'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
     );
 
     const brazeMessageProps: BrazeMessageProps = {

--- a/src/BannerWithLink/index.tsx
+++ b/src/BannerWithLink/index.tsx
@@ -130,7 +130,7 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
                         </LinkButton>
                     </ThemeProvider>
                 </div>
-                <div css={commonStyles.bottomRightComponent}>
+                <div css={[commonStyles.bottomRightComponent, styles.bottomRightComponent]}>
                     <div css={styles.image}>
                         <img src={imageUrl} alt="" />
                     </div>

--- a/src/BannerWithLink/styles.ts
+++ b/src/BannerWithLink/styles.ts
@@ -11,11 +11,11 @@ export const styles = {
     `,
     image: css`
         max-width: 100%;
-        max-height: 260px;
+        max-height: 300px;
         display: flex;
         justify-content: center;
         align-items: flex-end;
-        margin-top: -20px;
+        margin-top: ${space[2]}px;
 
         img {
             max-width: 100%;
@@ -64,6 +64,16 @@ export const styles = {
     `,
     heading: css`
         color: ${neutral[0]};
+    `,
+    bottomRightComponent: css`
+        ${from.desktop} {
+            padding-right: 0;
+            max-width: 45%;
+        }
+
+        ${from.wide} {
+            max-width: 48%;
+        }
     `,
 };
 

--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -77,7 +77,6 @@ export const styles = {
 
         ${from.desktop} {
             align-self: flex-end;
-            max-width: 40%;
             padding-right: ${space[4]}px;
             max-width: 42%;
             justify-content: flex-end;


### PR DESCRIPTION
## What does this change?

This PR tweaks the styling around the image a little bit, resulting in less empty space (requested by design). I've tried to balance the changes to ensure they work generally, across different image sizes we might use for this banner, rather than focusing solely on the image for the Gu in 2021 campaign.

## How to test

The changes are deployed to the [CODE storybook](https://braze-components.code.dev-gutools.co.uk/?path=/story/workinprogress-banner-bannerwithlink--default-story).

Also, see the Chromatic diff.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

At desktop width, with the default image:

### Before

<img width="1535" alt="Screenshot 2022-01-18 at 16 05 28" src="https://user-images.githubusercontent.com/379839/149976950-25313974-01c4-4951-933b-721a2c8c75e6.png">

### After

<img width="1552" alt="Screenshot 2022-01-18 at 16 05 44" src="https://user-images.githubusercontent.com/379839/149977008-34b4842f-e9e2-4b6e-99c5-c14e6a311b12.png">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
