### PR TITLE
Move BannerWithLink out of work-in-progress

### DIFF
--- a/src/BannerWithLink/index.stories.tsx
+++ b/src/BannerWithLink/index.stories.tsx
@@ -8,7 +8,7 @@ import { grid, withGrid } from '../../.storybook/grid/withGrid';
 
 export default {
     component: 'BannerWithLink',
-    title: 'WorkInProgress/Banner/BannerWithLink',
+    title: 'Banner/BannerWithLink',
     decorators: [withGrid],
     parameters: {
         grid: {


### PR DESCRIPTION
## What does this change?

Move the `BannerWithLink` component out of the work-in-progress folder in storybook. This PR can be merged once guardian/dotcom-rendering#3843 and guardian/frontend#24567 have been merged/deployed.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Run storybook locally.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
