### PR TITLE
Add click handlers to `BrazeEndOfArticleComponent` interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/braze-components",
-  "version": "5.4.0",
+  "version": "6.0.0-0",
   "description": "React components to render messages from Braze",
   "repository": "https://github.com/guardian/braze-components",
   "author": "The Guardian",

--- a/src/AUNewsletterEpic/index.stories.tsx
+++ b/src/AUNewsletterEpic/index.stories.tsx
@@ -57,6 +57,12 @@ const StoryTemplate = (
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
                     return new Promise((resolve) => setTimeout(() => resolve(), 1000));
                 }}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import type { OphanComponentEvent } from '@guardian/libs';
+
 import {
     COMPONENT_NAME as NEWSLETTER_EPIC_NAME,
     NewsletterEpic,
@@ -19,6 +21,7 @@ import {
     EpicWithSpecialHeader,
 } from './EpicWithSpecialHeader';
 import { buildBrazeMessageComponent, ComponentMapping } from './buildBrazeMessageComponent';
+import type { BrazeClickHandler } from './utils/tracking';
 
 type BrazeMessageProps = {
     [key: string]: string | undefined;
@@ -29,6 +32,8 @@ export type CommonEndOfArticleComponentProps = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
     countryCode?: string;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 };
 
 const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps> = {

--- a/src/DownToEarthNewsletterEpic/index.stories.tsx
+++ b/src/DownToEarthNewsletterEpic/index.stories.tsx
@@ -61,6 +61,12 @@ const StoryTemplate = (
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
                     return new Promise((resolve) => setTimeout(() => resolve(), 1000));
                 }}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -72,6 +72,12 @@ const StoryTemplate = (
                 brazeMessageProps={brazeMessageProps}
                 componentName={args.componentName}
                 subscribeToNewsletter={() => Promise.resolve()}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/EpicWithSpecialHeader/index.stories.tsx
+++ b/src/EpicWithSpecialHeader/index.stories.tsx
@@ -71,6 +71,12 @@ const StoryTemplate = (
                 brazeMessageProps={brazeMessageProps}
                 componentName={args.componentName}
                 subscribeToNewsletter={() => Promise.resolve()}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/UKNewsletterEpic/failure.stories.tsx
+++ b/src/UKNewsletterEpic/failure.stories.tsx
@@ -68,6 +68,12 @@ const StoryTemplate = (
                         setTimeout(() => (args.simulateFailure ? reject() : resolve()), 1000),
                     );
                 }}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/UKNewsletterEpic/index.stories.tsx
+++ b/src/UKNewsletterEpic/index.stories.tsx
@@ -61,6 +61,12 @@ const StoryTemplate = (
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
                     return new Promise((resolve) => setTimeout(() => resolve(), 1000));
                 }}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
+                }}
             />
         </StorybookWrapper>
     );

--- a/src/USNewsletterEpic/index.stories.tsx
+++ b/src/USNewsletterEpic/index.stories.tsx
@@ -57,6 +57,12 @@ const StoryTemplate = (
                     console.log(`subscribeToNewsletter invoked with id ${newsletterId}`);
                     return new Promise((resolve) => setTimeout(() => resolve(), 1000));
                 }}
+                logButtonClickWithBraze={(internalButtonId) => {
+                    console.log(`Button with internal ID ${internalButtonId} clicked`);
+                }}
+                submitComponentEvent={(componentEvent) => {
+                    console.log('submitComponentEvent called with: ', componentEvent);
+                }}
             />
         </StorybookWrapper>
     );


### PR DESCRIPTION
## What does this change?

We'd like to start tracking clicks in our epic components, like we do for our banner components. This is primarily so that we can control Braze canvas progression based on buttons clicked.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
