### PR TITLE
Wire click handlers with newsletter epic subscribe button

### DIFF
--- a/src/AUNewsletterEpic/index.tsx
+++ b/src/AUNewsletterEpic/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
+import type { BrazeClickHandler } from '../utils/tracking';
+import type { OphanComponentEvent } from '@guardian/libs';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/9f9f9c06ed5a323b13be816d5c160728c81d1bf9/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=87f06d1d5322f1fb8e2262d202f70e99';
@@ -18,6 +20,8 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 };
 
 export const AUNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/DownToEarthNewsletterEpic/index.tsx
+++ b/src/DownToEarthNewsletterEpic/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
+import type { BrazeClickHandler } from '../utils/tracking';
+import type { OphanComponentEvent } from '@guardian/libs';
 
 const newsletterId = '4147';
 
@@ -18,6 +20,8 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 };
 
 export const DownToEarthNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/NewsletterEpic/index.test.tsx
+++ b/src/NewsletterEpic/index.test.tsx
@@ -21,11 +21,15 @@ describe('NewsletterEpic', () => {
 
         it('calls subscribeToNewsletter with the correct id', async () => {
             const subscribeToNewsletter = jest.fn(() => Promise.resolve());
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            const noOpClickHandler = () => {};
 
             render(
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
+                    logButtonClickWithBraze={noOpClickHandler}
+                    submitComponentEvent={noOpClickHandler}
                 />,
             );
 
@@ -35,13 +39,44 @@ describe('NewsletterEpic', () => {
             expect(subscribeToNewsletter).toHaveBeenCalledWith(newsletterId);
         });
 
+        it('reports clicks to Ophan and Braze with the correct ID', async () => {
+            const subscribeToNewsletter = () => Promise.resolve();
+            const logButtonClickWithBraze = jest.fn();
+            const submitComponentEvent = jest.fn();
+            render(
+                <NewsletterEpic
+                    brazeMessageProps={brazeMessageProps}
+                    subscribeToNewsletter={subscribeToNewsletter}
+                    logButtonClickWithBraze={logButtonClickWithBraze}
+                    submitComponentEvent={submitComponentEvent}
+                />,
+            );
+
+            fireEvent.click(screen.getByText('Sign up'));
+            await screen.findByText(/Thank you/);
+
+            expect(logButtonClickWithBraze).toHaveBeenCalledWith(0);
+            expect(submitComponentEvent).toHaveBeenCalledWith({
+                component: {
+                    componentType: 'RETENTION_EPIC',
+                    id: brazeMessageProps.ophanComponentId,
+                },
+                action: 'CLICK',
+                value: '1',
+            });
+        });
+
         it('renders thank you when successful', async () => {
             const subscribeToNewsletter = () => Promise.resolve();
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            const noOpClickHandler = () => {};
 
             render(
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
+                    logButtonClickWithBraze={noOpClickHandler}
+                    submitComponentEvent={noOpClickHandler}
                 />,
             );
 

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -14,6 +14,8 @@ import {
 import { Button, buttonThemeBrandAlt } from '@guardian/source-react-components';
 import { COMPONENT_NAME, canRender } from './canRender';
 import { LoadingDots } from './LoadingDots';
+import type { BrazeClickHandler } from '../utils/tracking';
+import type { OphanComponentEvent } from '@guardian/libs';
 
 // Once https://github.com/guardian/source/pull/843 is merged and in a
 // @guardian/src-icons release we'll be able to bump the version on this project
@@ -127,11 +129,16 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 };
 
 type CTAProps = {
     subscribeToNewsletter: NewsletterSubscribeCallback;
     newsletterId: string;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    ophanComponentId?: string;
 };
 
 type SubscribeClickStatus = 'DEFAULT' | 'IN_PROGRESS' | 'SUCCESS' | 'FAILURE';
@@ -178,13 +185,49 @@ const SignUpButton: React.FC<SignUpButtonProps> = (props: SignUpButtonProps) => 
 };
 
 const CTA: React.FC<CTAProps> = (props: CTAProps) => {
-    const { subscribeToNewsletter, newsletterId } = props;
+    const {
+        subscribeToNewsletter,
+        newsletterId,
+        submitComponentEvent,
+        logButtonClickWithBraze,
+        ophanComponentId,
+    } = props;
 
     const [subscribeClickStatus, setSubscribeClickStatus] =
         useState<SubscribeClickStatus>('DEFAULT');
 
+    const catchAndLogErrors = (description: string, fn: () => void): void => {
+        try {
+            fn();
+        } catch (e) {
+            console.log(`Error (${description}): `, e.message);
+        }
+    };
+
     const onSignUpClick = () => {
         setSubscribeClickStatus('IN_PROGRESS');
+
+        // There's only one button to click on this epic, so we can hardcode the
+        // ID here.
+        const internalButtonId = 0;
+
+        catchAndLogErrors('ophanButtonClick', () => {
+            // Braze displays button id from 1, but internal representation is numbered from 0
+            // This ensures that the Button ID in Braze and Ophan will be the same
+            const externalButtonId = internalButtonId + 1;
+            submitComponentEvent({
+                component: {
+                    componentType: 'RETENTION_EPIC',
+                    id: ophanComponentId,
+                },
+                action: 'CLICK',
+                value: externalButtonId.toString(10),
+            });
+        });
+
+        catchAndLogErrors('brazeButtonClick', () => {
+            logButtonClickWithBraze(internalButtonId);
+        });
 
         subscribeToNewsletter(newsletterId as string)
             .then(() => setSubscribeClickStatus('SUCCESS'))
@@ -226,8 +269,18 @@ const CTA: React.FC<CTAProps> = (props: CTAProps) => {
 
 export const NewsletterEpic: React.FC<Props> = (props: Props) => {
     const {
-        brazeMessageProps: { header, frequency, paragraph1, paragraph2, imageUrl, newsletterId },
+        brazeMessageProps: {
+            header,
+            frequency,
+            paragraph1,
+            paragraph2,
+            imageUrl,
+            newsletterId,
+            ophanComponentId,
+        },
         subscribeToNewsletter,
+        submitComponentEvent,
+        logButtonClickWithBraze,
     } = props;
 
     if (!canRender(props.brazeMessageProps)) {
@@ -253,6 +306,9 @@ export const NewsletterEpic: React.FC<Props> = (props: Props) => {
                     <CTA
                         subscribeToNewsletter={subscribeToNewsletter}
                         newsletterId={newsletterId as string}
+                        submitComponentEvent={submitComponentEvent}
+                        logButtonClickWithBraze={logButtonClickWithBraze}
+                        ophanComponentId={ophanComponentId}
                     />
                 </div>
             </section>

--- a/src/UKNewsletterEpic/index.tsx
+++ b/src/UKNewsletterEpic/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
+import type { BrazeClickHandler } from '../utils/tracking';
+import type { OphanComponentEvent } from '@guardian/libs';
 
 const newsletterId = '4156';
 
@@ -18,6 +20,8 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 };
 
 export const UKNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/USNewsletterEpic/index.tsx
+++ b/src/USNewsletterEpic/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
+import type { BrazeClickHandler } from '../utils/tracking';
+import type { OphanComponentEvent } from '@guardian/libs';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=cca73e857c5093f39ef7a2a9dc2e7ce7';
@@ -18,6 +20,8 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
 };
 
 export const USNewsletterEpic: React.FC<Props> = (props: Props) => {


### PR DESCRIPTION
## What does this change?

Now when a reader clicks on the subscribe button on any of our newsletter epic components, the event will be reported to Ophan and Braze.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
