### PR TITLE
Use SvgClock icon from source-react-components

### DIFF
--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -1,5 +1,5 @@
 import { css, ThemeProvider } from '@emotion/react';
-import React, { useState, ReactElement } from 'react';
+import React, { useState } from 'react';
 import {
     brand,
     news,
@@ -11,25 +11,9 @@ import {
     headline,
     textSans,
 } from '@guardian/source-foundations';
-import { Button, buttonThemeBrandAlt } from '@guardian/source-react-components';
+import { Button, buttonThemeBrandAlt, SvgClock } from '@guardian/source-react-components';
 import { COMPONENT_NAME, canRender } from './canRender';
 import { LoadingDots } from './LoadingDots';
-
-// Once https://github.com/guardian/source/pull/843 is merged and in a
-// @guardian/src-icons release we'll be able to bump the version on this project
-// and replace this with:
-// import { SvgClock } from '@guardian/src-icons'
-export const SvgClock = (): ReactElement => {
-    return (
-        <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
-            <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M26 15c0 6.075-4.925 11-11 11S4 21.075 4 15 8.925 4 15 4s11 4.925 11 11zm-9.8-.35L15.475 6H14.5l-.75 9.375 1.275 1.275L22 16v-1l-5.8-.35z"
-            />
-        </svg>
-    );
-};
 
 const styles = {
     epicContainer: css`


### PR DESCRIPTION
## What does this change?

Use `SvgClock` icon from source-react-components instead of inlining. This was left over from wanting to use the icon before it had been added to source.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Chromatic shouldn't show any visual differences.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
