### PR TITLE
Add Epic remind me button

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     "@guardian/grid-client": "^1.1.1",
     "@guardian/libs": "^3.1.0",
     "@guardian/node-riffraff-artifact": "^0.3.2",
-    "@guardian/source-foundations": "^4.0.0-rc.1",
-    "@guardian/source-react-components": "^4.0.0-rc.2",
+    "@guardian/source-foundations": "^4.0.3",
+    "@guardian/source-react-components": "^4.0.2",
+		"@guardian/source-react-components-development-kitchen": "^0.0.33",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",
@@ -93,8 +94,9 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
     "@guardian/libs": "^3.1.0",
-    "@guardian/source-foundations": "^4.0.0-rc.1",
-    "@guardian/source-react-components": "^4.0.0-rc.2",
+    "@guardian/source-foundations": "^4.0.3",
+    "@guardian/source-react-components": "^4.0.2",
+		"@guardian/source-react-components-development-kitchen": "^0.0.33",
     "react": "17.0.2"
   },
   "dependencies": {},

--- a/src/AUNewsletterEpic/index.tsx
+++ b/src/AUNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/9f9f9c06ed5a323b13be816d5c160728c81d1bf9/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=87f06d1d5322f1fb8e2262d202f70e99';
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const AUNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/BrazeBannerComponent.ts
+++ b/src/BrazeBannerComponent.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { OphanComponentEvent } from '@guardian/libs';
 import {
     COMPONENT_NAME as DIGITAL_SUBSCRIBER_APP_BANNER_NAME,
     DigitalSubscriberAppBanner,
@@ -10,8 +9,12 @@ import {
     SpecialEditionBanner,
 } from './SpecialEditionBanner';
 import { COMPONENT_NAME as BANNER_WITH_LINK_NAME, BannerWithLink } from './BannerWithLink';
-import { BrazeClickHandler } from './utils/tracking';
-import { buildBrazeMessageComponent, ComponentMapping } from './buildBrazeMessageComponent';
+import type { BrazeClickHandler, SubmitComponentEvent } from './utils/tracking';
+import {
+    buildBrazeMessageComponent,
+    ComponentMapping,
+    HasConsolidatedTrackClick,
+} from './buildBrazeMessageComponent';
 
 type BrazeMessageProps = {
     [key: string]: string | undefined;
@@ -20,11 +23,11 @@ type BrazeMessageProps = {
 export type CommonBannerComponentProps = {
     componentName: string;
     logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    submitComponentEvent: SubmitComponentEvent;
     brazeMessageProps: BrazeMessageProps;
 };
 
-const BANNER_MAPPINGS: ComponentMapping<CommonBannerComponentProps> = {
+const BANNER_MAPPINGS: ComponentMapping<CommonBannerComponentProps & HasConsolidatedTrackClick> = {
     [DIGITAL_SUBSCRIBER_APP_BANNER_NAME]: DigitalSubscriberAppBanner,
     [APP_BANNER_NAME]: AppBanner,
     [SPECIAL_EDITION_BANNER_NAME]: SpecialEditionBanner,
@@ -32,4 +35,7 @@ const BANNER_MAPPINGS: ComponentMapping<CommonBannerComponentProps> = {
 };
 
 export const BrazeBannerComponent: React.FC<CommonBannerComponentProps> =
-    buildBrazeMessageComponent<CommonBannerComponentProps>(BANNER_MAPPINGS);
+    buildBrazeMessageComponent<CommonBannerComponentProps>(
+        'RETENTION_ENGAGEMENT_BANNER',
+        BANNER_MAPPINGS,
+    );

--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import type { OphanComponentEvent } from '@guardian/libs';
-
 import {
     COMPONENT_NAME as NEWSLETTER_EPIC_NAME,
     NewsletterEpic,
@@ -20,8 +18,12 @@ import {
     COMPONENT_NAME as EPIC_WITH_HEADER_IMAGE_NAME,
     EpicWithSpecialHeader,
 } from './EpicWithSpecialHeader';
-import { buildBrazeMessageComponent, ComponentMapping } from './buildBrazeMessageComponent';
-import type { BrazeClickHandler } from './utils/tracking';
+import {
+    buildBrazeMessageComponent,
+    ComponentMapping,
+    HasConsolidatedTrackClick,
+} from './buildBrazeMessageComponent';
+import type { BrazeClickHandler, SubmitComponentEvent } from './utils/tracking';
 
 type BrazeMessageProps = {
     [key: string]: string | undefined;
@@ -33,10 +35,12 @@ export type CommonEndOfArticleComponentProps = {
     subscribeToNewsletter: NewsletterSubscribeCallback;
     countryCode?: string;
     logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    submitComponentEvent: SubmitComponentEvent;
 };
 
-const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps> = {
+const END_OF_ARTICLE_MAPPINGS: ComponentMapping<
+    CommonEndOfArticleComponentProps & HasConsolidatedTrackClick
+> = {
     [NEWSLETTER_EPIC_NAME]: NewsletterEpic,
     [US_NEWSLETTER_EPIC_NAME]: USNewsletterEpic,
     [AU_NEWSLETTER_EPIC_NAME]: AUNewsletterEpic,
@@ -47,4 +51,7 @@ const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps
 };
 
 export const BrazeEndOfArticleComponent: React.FC<CommonEndOfArticleComponentProps> =
-    buildBrazeMessageComponent<CommonEndOfArticleComponentProps>(END_OF_ARTICLE_MAPPINGS);
+    buildBrazeMessageComponent<CommonEndOfArticleComponentProps>(
+        'RETENTION_EPIC',
+        END_OF_ARTICLE_MAPPINGS,
+    );

--- a/src/DownToEarthNewsletterEpic/index.tsx
+++ b/src/DownToEarthNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const newsletterId = '4147';
 
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const DownToEarthNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/Epic/ContributionsEpicButtons.tsx
+++ b/src/Epic/ContributionsEpicButtons.tsx
@@ -5,6 +5,9 @@ import { Button, LinkButton, SvgArrowRightStraight } from '@guardian/source-reac
 
 import { RemindMeConfirmation } from './RemindMeConfirmation';
 
+const PRIMARY_BUTTON_INTERNAL_ID = 0;
+const REMIND_ME_BUTTON_INTERNAL_ID = 1;
+
 const buttonWrapperStyles = css`
     margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
     display: flex;
@@ -57,9 +60,10 @@ const remindMeButtonOverrides = css`
 interface PrimaryButtonProps {
     buttonText: string;
     buttonUrl: string;
+    trackClick: (buttonId: number) => void;
 }
 
-const PrimaryButton = ({ buttonUrl, buttonText }: PrimaryButtonProps) => (
+const PrimaryButton = ({ buttonUrl, buttonText, trackClick }: PrimaryButtonProps) => (
     <div css={buttonMargins}>
         <ThemeProvider theme={contributionsTheme}>
             <LinkButton
@@ -69,6 +73,7 @@ const PrimaryButton = ({ buttonUrl, buttonText }: PrimaryButtonProps) => (
                 target="_blank"
                 rel="noopener noreferrer"
                 priority={'primary'}
+                onClick={() => trackClick(PRIMARY_BUTTON_INTERNAL_ID)}
             >
                 {buttonText}
             </LinkButton>
@@ -107,6 +112,7 @@ interface ContributionsEpicButtonsProps {
     remindMeButtonText?: string;
     remindMeConfirmationText?: string;
     remindMeConfirmationHeaderText?: string;
+    trackClick: (buttonId: number) => void;
 }
 type SectionState = 'DEFAULT' | 'REMINDER_CONFIRMED' | 'REMINDER_CONFIRMATION_CLOSED';
 
@@ -116,6 +122,7 @@ export const ContributionsEpicButtons = ({
     remindMeButtonText,
     remindMeConfirmationText,
     remindMeConfirmationHeaderText,
+    trackClick,
 }: ContributionsEpicButtonsProps): JSX.Element => {
     const [sectionState, setSectionState] = useState<SectionState>('DEFAULT');
 
@@ -132,7 +139,11 @@ export const ContributionsEpicButtons = ({
     if (sectionState === 'REMINDER_CONFIRMATION_CLOSED') {
         return (
             <div css={buttonWrapperStyles}>
-                <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} />
+                <PrimaryButton
+                    buttonText={buttonText}
+                    buttonUrl={buttonUrl}
+                    trackClick={trackClick}
+                />
 
                 <PaymentIcons />
             </div>
@@ -141,12 +152,15 @@ export const ContributionsEpicButtons = ({
 
     return (
         <div css={buttonWrapperStyles}>
-            <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} />
+            <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} trackClick={trackClick} />
 
             {remindMeButtonText && remindMeConfirmationText && (
                 <RemindMeButton
                     remindMeButtonText={remindMeButtonText}
-                    onClick={() => setSectionState('REMINDER_CONFIRMED')}
+                    onClick={() => {
+                        trackClick(REMIND_ME_BUTTON_INTERNAL_ID);
+                        setSectionState('REMINDER_CONFIRMED');
+                    }}
                 />
             )}
 

--- a/src/Epic/ContributionsEpicButtons.tsx
+++ b/src/Epic/ContributionsEpicButtons.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { css, ThemeProvider } from '@emotion/react';
 import { neutral, brandAlt, space } from '@guardian/source-foundations';
-import { LinkButton, SvgArrowRightStraight } from '@guardian/source-react-components';
+import { Button, LinkButton, SvgArrowRightStraight } from '@guardian/source-react-components';
+
+import { RemindMeConfirmation } from './RemindMeConfirmation';
 
 const buttonWrapperStyles = css`
     margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
@@ -42,43 +44,113 @@ const contributionsTheme = {
     link: buttonStyles,
 };
 
-interface ContributionsEpicButtonsProps {
+const remindMeButtonOverrides = css`
+    border: 1px solid ${neutral[7]} !important;
+    background-color: transparent !important;
+    color: ${neutral[7]} !important;
+
+    :hover {
+        background-color: ${neutral[86]} !important;
+    }
+`;
+
+interface PrimaryButtonProps {
     buttonText: string;
     buttonUrl: string;
 }
 
+const PrimaryButton = ({ buttonUrl, buttonText }: PrimaryButtonProps) => (
+    <div css={buttonMargins}>
+        <ThemeProvider theme={contributionsTheme}>
+            <LinkButton
+                href={buttonUrl}
+                icon={<SvgArrowRightStraight />}
+                iconSide="right"
+                target="_blank"
+                rel="noopener noreferrer"
+                priority={'primary'}
+            >
+                {buttonText}
+            </LinkButton>
+        </ThemeProvider>
+    </div>
+);
+
+interface RemindMeButtonProps {
+    remindMeButtonText: string;
+    onClick: () => void;
+}
+
+const RemindMeButton = ({ remindMeButtonText, onClick }: RemindMeButtonProps) => (
+    <div css={buttonMargins}>
+        <ThemeProvider theme={contributionsTheme}>
+            <Button onClick={() => onClick()} priority="tertiary" css={remindMeButtonOverrides}>
+                {remindMeButtonText}
+            </Button>
+        </ThemeProvider>
+    </div>
+);
+
+const PaymentIcons = () => (
+    <img
+        width={422}
+        height={60}
+        src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+        alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+        css={paymentImageStyles}
+    />
+);
+
+interface ContributionsEpicButtonsProps {
+    buttonText: string;
+    buttonUrl: string;
+    remindMeButtonText?: string;
+    remindMeConfirmationText?: string;
+    remindMeConfirmationHeaderText?: string;
+}
+type SectionState = 'DEFAULT' | 'REMINDER_CONFIRMED' | 'REMINDER_CONFIRMATION_CLOSED';
+
 export const ContributionsEpicButtons = ({
     buttonText,
     buttonUrl,
-}: ContributionsEpicButtonsProps): JSX.Element | null => {
-    if (!buttonText) {
-        return null;
+    remindMeButtonText,
+    remindMeConfirmationText,
+    remindMeConfirmationHeaderText,
+}: ContributionsEpicButtonsProps): JSX.Element => {
+    const [sectionState, setSectionState] = useState<SectionState>('DEFAULT');
+
+    if (sectionState === 'REMINDER_CONFIRMED') {
+        return (
+            <RemindMeConfirmation
+                remindMeConfirmationText={remindMeConfirmationText as string}
+                remindMeConfirmationHeaderText={remindMeConfirmationHeaderText as string}
+                onClose={() => setSectionState('REMINDER_CONFIRMATION_CLOSED')}
+            />
+        );
+    }
+
+    if (sectionState === 'REMINDER_CONFIRMATION_CLOSED') {
+        return (
+            <div css={buttonWrapperStyles}>
+                <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} />
+
+                <PaymentIcons />
+            </div>
+        );
     }
 
     return (
         <div css={buttonWrapperStyles}>
-            <div css={buttonMargins}>
-                <ThemeProvider theme={contributionsTheme}>
-                    <LinkButton
-                        href={buttonUrl}
-                        icon={<SvgArrowRightStraight />}
-                        iconSide="right"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        priority={'primary'}
-                    >
-                        {buttonText}
-                    </LinkButton>
-                </ThemeProvider>
-            </div>
+            <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} />
 
-            <img
-                width={422}
-                height={60}
-                src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-                alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-                css={paymentImageStyles}
-            />
+            {remindMeButtonText && remindMeConfirmationText && (
+                <RemindMeButton
+                    remindMeButtonText={remindMeButtonText}
+                    onClick={() => setSectionState('REMINDER_CONFIRMED')}
+                />
+            )}
+
+            <PaymentIcons />
         </div>
     );
 };

--- a/src/Epic/RemindMeConfirmation.tsx
+++ b/src/Epic/RemindMeConfirmation.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { body, from, headline, neutral, space } from '@guardian/source-foundations';
+import { Button, SvgCross } from '@guardian/source-react-components';
+import { Lines } from '@guardian/source-react-components-development-kitchen';
+
+const reminderConfirmationContainerStyles = css`
+    position: relative;
+`;
+
+const confirmationCloseButtonStyles = css`
+    svg {
+        fill: ${neutral[7]};
+    }
+`;
+
+const closeButtonContainerStyles = css`
+    display: none;
+    position: absolute;
+    top: 15px;
+    right: 0;
+    z-index: 99999;
+
+    ${from.tablet} {
+        display: block;
+    }
+`;
+
+const successTextStyles = css`
+    ${body.medium()};
+    margin: 0;
+
+    a {
+        color: ${neutral[0]};
+    }
+`;
+
+const successHeadingStyles = css`
+    ${headline.xxsmall({ fontWeight: 'bold' })};
+    margin: ${space[2]}px 0;
+`;
+
+type Props = {
+    remindMeConfirmationHeaderText: string;
+    remindMeConfirmationText: string;
+    onClose: () => void;
+};
+
+export const RemindMeConfirmation = ({
+    remindMeConfirmationText,
+    remindMeConfirmationHeaderText,
+    onClose,
+}: Props): JSX.Element => {
+    return (
+        <div css={reminderConfirmationContainerStyles}>
+            <div css={closeButtonContainerStyles}>
+                <Button
+                    onClick={() => onClose()}
+                    icon={<SvgCross />}
+                    priority="subdued"
+                    size="small"
+                    hideLabel
+                    css={confirmationCloseButtonStyles}
+                >
+                    Close
+                </Button>
+            </div>
+            <Lines />
+            {remindMeConfirmationHeaderText && (
+                <h4 css={successHeadingStyles}>{remindMeConfirmationHeaderText}</h4>
+            )}
+            <p css={successTextStyles}>
+                {remindMeConfirmationText} You can manage your email preferences in the My Account,{' '}
+                <a href="https://manage.theguardian.com/email-prefs">emails and marketing tab</a>.
+                If you have any questions about contributing, please{' '}
+                <a href="mailto:contribution.support@theguardian.com">contact us</a>.
+            </p>
+        </div>
+    );
+};

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -35,11 +35,20 @@ export default {
             type: { name: 'string', required: true },
             description: 'Button label text',
         },
-        buttonUrl: {
-            name: 'buttonUrl',
-            type: { name: 'string', required: true },
-            description:
-                'Destination link for the button. See Braze user guide for tracking params.',
+        remindMeButtonText: {
+            name: 'remindMeButtonText',
+            type: { name: 'string', required: false },
+            description: 'Text for secondary remind me button',
+        },
+        remindMeConfirmationText: {
+            name: 'remindMeConfirmationText',
+            type: { name: 'string', required: false },
+            description: 'Text to display when user clicks the remind me button',
+        },
+        remindMeConfirmationHeaderText: {
+            name: 'remindMeConfirmationHeaderText',
+            type: { name: 'string', required: false },
+            description: 'Header text to display when user clicks the remind me button',
         },
     },
 };
@@ -62,6 +71,9 @@ const StoryTemplate = (
         paragraph7: args.paragraph7,
         paragraph8: args.paragraph8,
         paragraph9: args.paragraph9,
+        remindMeButtonText: args.remindMeButtonText,
+        remindMeConfirmationText: args.remindMeConfirmationText,
+        remindMeConfirmationHeaderText: args.remindMeConfirmationHeaderText,
     };
 
     knobsData.set({ ...brazeMessageProps, componentName: args.componentName });
@@ -105,3 +117,29 @@ DefaultStory.args = {
 };
 
 DefaultStory.story = { name: 'Epic' };
+
+export const WithReminderStory = StoryTemplate.bind({});
+
+WithReminderStory.args = {
+    heading: 'Since you’re here...',
+    paragraph1:
+        '... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
+    paragraph2:
+        'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
+    paragraph3:
+        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
+    paragraph4:
+        'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
+    highlightedText:
+        'Support <a href="https://example.com">The Guardian</a> from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
+    buttonText: 'Support The Guardian',
+    buttonUrl: 'https://support.theguardian.com/contribute',
+    ophanComponentId: 'example_ophan_component_id',
+    slotName: 'EndOfArticle',
+    componentName: 'Epic',
+    remindMeButtonText: 'Remind me in May',
+    remindMeConfirmationText: "Okay, we'll send you an email in May.",
+    remindMeConfirmationHeaderText: 'Thank you! Your reminder is set.',
+};
+
+WithReminderStory.story = { name: 'Epic with Remind Me CTA' };

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -126,10 +126,6 @@ WithReminderStory.args = {
         '... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
     paragraph2:
         'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
-    paragraph3:
-        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
-    paragraph4:
-        'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
     highlightedText:
         'Support <a href="https://example.com">The Guardian</a> from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
     buttonText: 'Support The Guardian',

--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -5,6 +5,7 @@ import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { COMPONENT_NAME, canRender, parseParagraphs } from './canRender';
 export { COMPONENT_NAME };
 import { replaceNonArticleCountPlaceholders } from './placeholders';
+import { TrackClick } from '../utils/tracking';
 
 // Custom styles for <a> tags in the Epic content
 const linkStyles = css`
@@ -71,6 +72,7 @@ export type EpicProps = {
     brazeMessageProps: BrazeMessageProps;
     countryCode?: string;
     headerSection?: React.ReactNode;
+    trackClick: TrackClick;
 };
 
 export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
@@ -83,9 +85,11 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
             remindMeButtonText,
             remindMeConfirmationHeaderText,
             remindMeConfirmationText,
+            ophanComponentId,
         },
         countryCode,
         headerSection,
+        trackClick,
     } = props;
 
     if (!canRender(props.brazeMessageProps)) {
@@ -123,6 +127,12 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                         remindMeButtonText={remindMeButtonText}
                         remindMeConfirmationText={remindMeConfirmationText}
                         remindMeConfirmationHeaderText={remindMeConfirmationHeaderText}
+                        trackClick={(buttonId: number) =>
+                            trackClick({
+                                internalButtonId: buttonId,
+                                ophanComponentId: ophanComponentId as string,
+                            })
+                        }
                     ></ContributionsEpicButtons>
                 </section>
             </div>

--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -61,6 +61,9 @@ export type BrazeMessageProps = {
     paragraph7?: string;
     paragraph8?: string;
     paragraph9?: string;
+    remindMeButtonText?: string;
+    remindMeConfirmationHeaderText?: string;
+    remindMeConfirmationText?: string;
 };
 
 export type EpicProps = {
@@ -72,7 +75,15 @@ export type EpicProps = {
 
 export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
     const {
-        brazeMessageProps: { heading, buttonText, buttonUrl, highlightedText },
+        brazeMessageProps: {
+            heading,
+            buttonText,
+            buttonUrl,
+            highlightedText,
+            remindMeButtonText,
+            remindMeConfirmationHeaderText,
+            remindMeConfirmationText,
+        },
         countryCode,
         headerSection,
     } = props;
@@ -109,6 +120,9 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                     <ContributionsEpicButtons
                         buttonText={buttonText as string}
                         buttonUrl={buttonUrl as string}
+                        remindMeButtonText={remindMeButtonText}
+                        remindMeConfirmationText={remindMeConfirmationText}
+                        remindMeConfirmationHeaderText={remindMeConfirmationHeaderText}
                     ></ContributionsEpicButtons>
                 </section>
             </div>

--- a/src/NewsletterEpic/index.test.tsx
+++ b/src/NewsletterEpic/index.test.tsx
@@ -28,8 +28,7 @@ describe('NewsletterEpic', () => {
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
-                    logButtonClickWithBraze={noOpClickHandler}
-                    submitComponentEvent={noOpClickHandler}
+                    trackClick={noOpClickHandler}
                 />,
             );
 
@@ -39,30 +38,23 @@ describe('NewsletterEpic', () => {
             expect(subscribeToNewsletter).toHaveBeenCalledWith(newsletterId);
         });
 
-        it('reports clicks to Ophan and Braze with the correct ID', async () => {
+        it('reports clicks with the correct ID', async () => {
             const subscribeToNewsletter = () => Promise.resolve();
-            const logButtonClickWithBraze = jest.fn();
-            const submitComponentEvent = jest.fn();
+            const trackClick = jest.fn();
             render(
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
-                    logButtonClickWithBraze={logButtonClickWithBraze}
-                    submitComponentEvent={submitComponentEvent}
+                    trackClick={trackClick}
                 />,
             );
 
             fireEvent.click(screen.getByText('Sign up'));
             await screen.findByText(/Thank you/);
 
-            expect(logButtonClickWithBraze).toHaveBeenCalledWith(0);
-            expect(submitComponentEvent).toHaveBeenCalledWith({
-                component: {
-                    componentType: 'RETENTION_EPIC',
-                    id: brazeMessageProps.ophanComponentId,
-                },
-                action: 'CLICK',
-                value: '1',
+            expect(trackClick).toHaveBeenCalledWith({
+                internalButtonId: 0,
+                ophanComponentId: 'ophan_component_id',
             });
         });
 
@@ -75,8 +67,7 @@ describe('NewsletterEpic', () => {
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
-                    logButtonClickWithBraze={noOpClickHandler}
-                    submitComponentEvent={noOpClickHandler}
+                    trackClick={noOpClickHandler}
                 />,
             );
 

--- a/src/UKNewsletterEpic/index.tsx
+++ b/src/UKNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const newsletterId = '4156';
 
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const UKNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/USNewsletterEpic/index.tsx
+++ b/src/USNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=cca73e857c5093f39ef7a2a9dc2e7ce7';
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const USNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/buildBrazeMessageComponent.test.tsx
+++ b/src/buildBrazeMessageComponent.test.tsx
@@ -6,15 +6,25 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { buildBrazeMessageComponent } from './buildBrazeMessageComponent';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noOp = () => {};
+
 describe('buildBrazeMessageComponent', () => {
     it('renders the correct component when a valid componentName is passed', () => {
         const ExampleComponent = jest.fn(() => null);
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         const mappings = {
             ExampleComponent,
         };
-        const BrazeMessageComponent = buildBrazeMessageComponent(mappings);
+        const BrazeMessageComponent = buildBrazeMessageComponent('RETENTION_EPIC', mappings);
 
-        render(<BrazeMessageComponent componentName={'ExampleComponent'} />);
+        render(
+            <BrazeMessageComponent
+                componentName={'ExampleComponent'}
+                logButtonClickWithBraze={noOp}
+                submitComponentEvent={noOp}
+            />,
+        );
 
         expect(ExampleComponent).toHaveBeenCalled();
     });
@@ -24,9 +34,15 @@ describe('buildBrazeMessageComponent', () => {
         const mappings = {
             ExampleComponent,
         };
-        const BrazeMessageComponent = buildBrazeMessageComponent(mappings);
+        const BrazeMessageComponent = buildBrazeMessageComponent('RETENTION_EPIC', mappings);
 
-        render(<BrazeMessageComponent componentName={'NoSuchComponent'} />);
+        render(
+            <BrazeMessageComponent
+                componentName={'NoSuchComponent'}
+                logButtonClickWithBraze={noOp}
+                submitComponentEvent={noOp}
+            />,
+        );
 
         expect(ExampleComponent).not.toHaveBeenCalled();
     });

--- a/src/buildBrazeMessageComponent.tsx
+++ b/src/buildBrazeMessageComponent.tsx
@@ -1,15 +1,32 @@
 import React from 'react';
+import type { BrazeClickHandler, SubmitComponentEvent, TrackClick } from './utils/tracking';
+import { buildTrackClick, OphanComponentType } from './utils/tracking';
 
 interface HasComponentName {
     componentName: string;
+}
+
+interface HasClickTrackingCallbacks {
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: SubmitComponentEvent;
+}
+
+export interface HasConsolidatedTrackClick {
+    trackClick: TrackClick;
 }
 
 export type ComponentMapping<A> = {
     [key: string]: React.FC<A>;
 };
 
-export function buildBrazeMessageComponent<A extends HasComponentName>(
-    mappings: ComponentMapping<A>,
+// We know in here that we have access to logButtonClickWithBraze and
+// submitComponentEvent (using the HasClickTrackingCallbacks interface). So,
+// we're able to consolidate these into a single trackClick callback in the
+// underlying component(s), as specified by the HasConsolidatedTrackClick
+// interface.
+export function buildBrazeMessageComponent<A extends HasComponentName & HasClickTrackingCallbacks>(
+    ophanComponentType: OphanComponentType,
+    mappings: ComponentMapping<A & HasConsolidatedTrackClick>,
 ): React.FC<A> {
     const BrazeMessageComponent = (props: A) => {
         const ComponentToRender = mappings[props.componentName];
@@ -18,7 +35,18 @@ export function buildBrazeMessageComponent<A extends HasComponentName>(
             return null;
         }
 
-        return <ComponentToRender {...props} />;
+        const trackClick = buildTrackClick({
+            submitComponentEvent: props.submitComponentEvent,
+            logButtonClickWithBraze: props.logButtonClickWithBraze,
+            ophanComponentType,
+        });
+
+        const augmentedProps = {
+            ...props,
+            trackClick,
+        };
+
+        return <ComponentToRender {...augmentedProps} />;
     };
 
     return BrazeMessageComponent;

--- a/src/utils/tracking.test.tsx
+++ b/src/utils/tracking.test.tsx
@@ -1,0 +1,68 @@
+import { buildTrackClick } from './tracking';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noOpCallback = () => {};
+
+describe('buildTrackClick', () => {
+    it('returns a function which calls submitComponentEvent with the correct args', () => {
+        const ophanComponentType = 'RETENTION_EPIC';
+        const submitComponentEvent = jest.fn();
+        const logButtonClickWithBraze = noOpCallback;
+        const trackClick = buildTrackClick({
+            ophanComponentType,
+            submitComponentEvent,
+            logButtonClickWithBraze,
+        });
+
+        const internalButtonId = 0;
+        const ophanComponentId = 'example_id';
+        trackClick({ ophanComponentId, internalButtonId });
+
+        expect(submitComponentEvent).toHaveBeenCalledWith({
+            action: 'CLICK',
+            component: {
+                componentType: ophanComponentType,
+                id: ophanComponentId,
+            },
+            // Braze displays the button id indexed from 1, so we add one when tracking in Ophan
+            // so that the values match:
+            value: '1',
+        });
+    });
+
+    it('returns a function which calls logButtonClickWithBraze with the correct args', () => {
+        const ophanComponentType = 'RETENTION_EPIC';
+        const submitComponentEvent = noOpCallback;
+        const logButtonClickWithBraze = jest.fn();
+        const trackClick = buildTrackClick({
+            ophanComponentType,
+            submitComponentEvent,
+            logButtonClickWithBraze,
+        });
+
+        const internalButtonId = 0;
+        const ophanComponentId = 'example_id';
+        trackClick({ ophanComponentId, internalButtonId });
+
+        expect(logButtonClickWithBraze).toHaveBeenCalledWith(internalButtonId);
+    });
+
+    it('catches errors in callbacks, so the other is not affected', () => {
+        const ophanComponentType = 'RETENTION_EPIC';
+        const submitComponentEvent = () => {
+            throw new Error('submitComponentEvent error!');
+        };
+        const logButtonClickWithBraze = jest.fn();
+        const trackClick = buildTrackClick({
+            ophanComponentType,
+            submitComponentEvent,
+            logButtonClickWithBraze,
+        });
+
+        const internalButtonId = 0;
+        const ophanComponentId = 'example_id';
+        trackClick({ ophanComponentId, internalButtonId });
+
+        expect(logButtonClickWithBraze).toHaveBeenCalled();
+    });
+});

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -1,3 +1,51 @@
-type BrazeClickHandler = (internalButtonId: number) => void;
+import type { OphanComponentEvent } from '@guardian/libs';
 
-export { BrazeClickHandler };
+type BrazeClickHandler = (internalButtonId: number) => void;
+type SubmitComponentEvent = (componentEvent: OphanComponentEvent) => void;
+
+type OphanComponentType = 'RETENTION_EPIC' | 'RETENTION_ENGAGEMENT_BANNER';
+
+type Props = {
+    submitComponentEvent: SubmitComponentEvent;
+    logButtonClickWithBraze: BrazeClickHandler;
+    ophanComponentType: OphanComponentType;
+};
+
+type InnerProps = {
+    ophanComponentId: string;
+    internalButtonId: number;
+};
+
+type TrackClick = (innerProps: InnerProps) => void;
+
+const catchAndLogErrors = (description: string, fn: () => void): void => {
+    try {
+        fn();
+    } catch (e) {
+        console.log(`Error (${description}): `, e.message);
+    }
+};
+
+const buildTrackClick =
+    ({ submitComponentEvent, logButtonClickWithBraze, ophanComponentType }: Props): TrackClick =>
+    ({ internalButtonId, ophanComponentId }: InnerProps) => {
+        catchAndLogErrors('ophanButtonClick', () => {
+            // Braze displays button id from 1, but internal representation is numbered from 0
+            // This ensures that the Button ID in Braze and Ophan will be the same
+            const externalButtonId = internalButtonId + 1;
+            submitComponentEvent({
+                component: {
+                    componentType: ophanComponentType,
+                    id: ophanComponentId,
+                },
+                action: 'CLICK',
+                value: externalButtonId.toString(10),
+            });
+        });
+
+        catchAndLogErrors('brazeButtonClick', () => {
+            logButtonClickWithBraze(internalButtonId);
+        });
+    };
+
+export { BrazeClickHandler, SubmitComponentEvent, TrackClick, OphanComponentType, buildTrackClick };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,15 +1557,22 @@
     yaml "^1.7.2"
     yargs "^15.4.1"
 
-"@guardian/source-foundations@^4.0.0-rc.1":
-  version "4.0.0-rc.1"
-  resolved "https://registry.npmjs.org/@guardian/source-foundations/-/source-foundations-4.0.0-rc.1.tgz#981c0ec19a3d7b59ca6d604bf1cbcf9f8db8257f"
-  integrity sha512-I7Tb4xpjhOnjd4sCJ1YstkxMpYLxNMwdR0YZFatTGUWsWRGCUDk4vIwDbrzX2/SE/okSwOQ/UPc0bYqvdCOzzg==
+"@guardian/source-foundations@^4.0.3":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-4.1.0.tgz#dbcc3fa540bedc61d58dd483b4c96d2042b3760d"
+  integrity sha512-jTeJd43AoEZCltg6ZzGvh5KjUaWMnrN9O/HmWrjCZWg4rqyrRTc3lwCyRmYjTEC9KM3AotOUoF1Y93tnG074Vw==
+  dependencies:
+    mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components@^4.0.0-rc.2":
-  version "4.0.0-rc.2"
-  resolved "https://registry.npmjs.org/@guardian/source-react-components/-/source-react-components-4.0.0-rc.2.tgz#e306ad26cf155a67b8c26c21c038e8ae99c08065"
-  integrity sha512-H5Y80aAKP9G3pj1Cj3ygd5mP0GbwE6lI91l98yOTh6I1yfcthEzP4faCLKYVn9UvKexHwEhBEjjj8W99YmnfTQ==
+"@guardian/source-react-components-development-kitchen@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-0.0.33.tgz#d785992f833f6072072848f1d748d6f9b1e82cb7"
+  integrity sha512-/jpVvjzWxbnhf7Of7lVRv67SAa2i2bQGsvTz+JsZIjgllmZKSLfuwn8SoYzJnQIiRhJhPzRY6PZFhMhZOtcPDw==
+
+"@guardian/source-react-components@^4.0.2":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.1.1.tgz#5826bc138253ff104f2bb282f9e50771c8e5387a"
+  integrity sha512-1uXWJ0lEZ8ZFs10UDA0rZhNnsXiojh8CDoh7x+j4B6EIm3+xXBUnS3s7FJZzSGPw65IWKxwnbeift5cPrk4HAA==
 
 "@hapi/hoek@^9.0.0":
   version "9.2.0"
@@ -10443,6 +10450,11 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-svg-data-uri@^1.3.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.3.tgz#43177b2e93766ba338931a3e2a84a3dfd3a222b8"
+  integrity sha512-gSfqpMRC8IxghvMcxzzmMnWpXAChSA+vy4cia33RgerMS8Fex95akUyQZPbxJJmeBGiGmK7n/1OpUX8ksRjIdA==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## What does this change?

This add the remind me button to the Braze `Epic` component.

We've introduced 3 new (optional) props/values to be passed from Braze:

* `remindMeButtonText`
* `remindMeConfirmationText`
* `remindMeConfirmationHeaderText`

If all three are specified, we'll render the remind me button.

As well as the dynamic/configurable confirmation text, we also include some hardcoded privacy text (supplied by Gavin).

~~Note that I've not included the click tracking for these epic buttons yet. I'm working on that in a separate branch as I'm experimenting with an approach which requires some refactoring and I didn't want this PR to get too big. We wouldn't want to use the remind me button as it's implemented in this PR until the tracking is done (as we wouldn't know when a user has clicked the button, and to schedule the email).~~ The PR to add the click tracking, #304, has now been merged into this branch.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Storybook!

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![2022-03-10 13 45 01](https://user-images.githubusercontent.com/379839/157675132-bd2f7276-856e-40d9-9da5-9792c65e27e9.gif)


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [x] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
