### PR TITLE
Epic Remind Me Button Tracking

### DIFF
--- a/src/AUNewsletterEpic/index.tsx
+++ b/src/AUNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/9f9f9c06ed5a323b13be816d5c160728c81d1bf9/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=87f06d1d5322f1fb8e2262d202f70e99';
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const AUNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/BrazeBannerComponent.ts
+++ b/src/BrazeBannerComponent.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { OphanComponentEvent } from '@guardian/libs';
 import {
     COMPONENT_NAME as DIGITAL_SUBSCRIBER_APP_BANNER_NAME,
     DigitalSubscriberAppBanner,
@@ -10,8 +9,12 @@ import {
     SpecialEditionBanner,
 } from './SpecialEditionBanner';
 import { COMPONENT_NAME as BANNER_WITH_LINK_NAME, BannerWithLink } from './BannerWithLink';
-import { BrazeClickHandler } from './utils/tracking';
-import { buildBrazeMessageComponent, ComponentMapping } from './buildBrazeMessageComponent';
+import type { BrazeClickHandler, SubmitComponentEvent } from './utils/tracking';
+import {
+    buildBrazeMessageComponent,
+    ComponentMapping,
+    HasConsolidatedTrackClick,
+} from './buildBrazeMessageComponent';
 
 type BrazeMessageProps = {
     [key: string]: string | undefined;
@@ -20,11 +23,11 @@ type BrazeMessageProps = {
 export type CommonBannerComponentProps = {
     componentName: string;
     logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    submitComponentEvent: SubmitComponentEvent;
     brazeMessageProps: BrazeMessageProps;
 };
 
-const BANNER_MAPPINGS: ComponentMapping<CommonBannerComponentProps> = {
+const BANNER_MAPPINGS: ComponentMapping<CommonBannerComponentProps & HasConsolidatedTrackClick> = {
     [DIGITAL_SUBSCRIBER_APP_BANNER_NAME]: DigitalSubscriberAppBanner,
     [APP_BANNER_NAME]: AppBanner,
     [SPECIAL_EDITION_BANNER_NAME]: SpecialEditionBanner,
@@ -32,4 +35,7 @@ const BANNER_MAPPINGS: ComponentMapping<CommonBannerComponentProps> = {
 };
 
 export const BrazeBannerComponent: React.FC<CommonBannerComponentProps> =
-    buildBrazeMessageComponent<CommonBannerComponentProps>(BANNER_MAPPINGS);
+    buildBrazeMessageComponent<CommonBannerComponentProps>(
+        'RETENTION_ENGAGEMENT_BANNER',
+        BANNER_MAPPINGS,
+    );

--- a/src/BrazeEndOfArticleComponent.ts
+++ b/src/BrazeEndOfArticleComponent.ts
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import type { OphanComponentEvent } from '@guardian/libs';
-
 import {
     COMPONENT_NAME as NEWSLETTER_EPIC_NAME,
     NewsletterEpic,
@@ -20,8 +18,12 @@ import {
     COMPONENT_NAME as EPIC_WITH_HEADER_IMAGE_NAME,
     EpicWithSpecialHeader,
 } from './EpicWithSpecialHeader';
-import { buildBrazeMessageComponent, ComponentMapping } from './buildBrazeMessageComponent';
-import type { BrazeClickHandler } from './utils/tracking';
+import {
+    buildBrazeMessageComponent,
+    ComponentMapping,
+    HasConsolidatedTrackClick,
+} from './buildBrazeMessageComponent';
+import type { BrazeClickHandler, SubmitComponentEvent } from './utils/tracking';
 
 type BrazeMessageProps = {
     [key: string]: string | undefined;
@@ -33,10 +35,12 @@ export type CommonEndOfArticleComponentProps = {
     subscribeToNewsletter: NewsletterSubscribeCallback;
     countryCode?: string;
     logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    submitComponentEvent: SubmitComponentEvent;
 };
 
-const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps> = {
+const END_OF_ARTICLE_MAPPINGS: ComponentMapping<
+    CommonEndOfArticleComponentProps & HasConsolidatedTrackClick
+> = {
     [NEWSLETTER_EPIC_NAME]: NewsletterEpic,
     [US_NEWSLETTER_EPIC_NAME]: USNewsletterEpic,
     [AU_NEWSLETTER_EPIC_NAME]: AUNewsletterEpic,
@@ -47,4 +51,7 @@ const END_OF_ARTICLE_MAPPINGS: ComponentMapping<CommonEndOfArticleComponentProps
 };
 
 export const BrazeEndOfArticleComponent: React.FC<CommonEndOfArticleComponentProps> =
-    buildBrazeMessageComponent<CommonEndOfArticleComponentProps>(END_OF_ARTICLE_MAPPINGS);
+    buildBrazeMessageComponent<CommonEndOfArticleComponentProps>(
+        'RETENTION_EPIC',
+        END_OF_ARTICLE_MAPPINGS,
+    );

--- a/src/DownToEarthNewsletterEpic/index.tsx
+++ b/src/DownToEarthNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const newsletterId = '4147';
 
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const DownToEarthNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/Epic/ContributionsEpicButtons.tsx
+++ b/src/Epic/ContributionsEpicButtons.tsx
@@ -5,6 +5,9 @@ import { Button, LinkButton, SvgArrowRightStraight } from '@guardian/source-reac
 
 import { RemindMeConfirmation } from './RemindMeConfirmation';
 
+const PRIMARY_BUTTON_INTERNAL_ID = 0;
+const REMIND_ME_BUTTON_INTERNAL_ID = 1;
+
 const buttonWrapperStyles = css`
     margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
     display: flex;
@@ -53,9 +56,10 @@ const remindMeButtonOverrides = css`
 interface PrimaryButtonProps {
     buttonText: string;
     buttonUrl: string;
+    trackClick: (buttonId: number) => void;
 }
 
-const PrimaryButton = ({ buttonUrl, buttonText }: PrimaryButtonProps) => (
+const PrimaryButton = ({ buttonUrl, buttonText, trackClick }: PrimaryButtonProps) => (
     <div css={buttonMargins}>
         <ThemeProvider theme={contributionsTheme}>
             <LinkButton
@@ -65,6 +69,7 @@ const PrimaryButton = ({ buttonUrl, buttonText }: PrimaryButtonProps) => (
                 target="_blank"
                 rel="noopener noreferrer"
                 priority={'primary'}
+                onClick={() => trackClick(PRIMARY_BUTTON_INTERNAL_ID)}
             >
                 {buttonText}
             </LinkButton>
@@ -101,6 +106,7 @@ interface ContributionsEpicButtonsProps {
     remindMeButtonText?: string;
     remindMeConfirmationText?: string;
     remindMeConfirmationHeaderText?: string;
+    trackClick: (buttonId: number) => void;
 }
 type SectionState = 'DEFAULT' | 'REMINDER_CONFIRMED' | 'REMINDER_CONFIRMATION_CLOSED';
 
@@ -110,6 +116,7 @@ export const ContributionsEpicButtons = ({
     remindMeButtonText,
     remindMeConfirmationText,
     remindMeConfirmationHeaderText,
+    trackClick,
 }: ContributionsEpicButtonsProps): JSX.Element => {
     const [sectionState, setSectionState] = useState<SectionState>('DEFAULT');
 
@@ -126,7 +133,11 @@ export const ContributionsEpicButtons = ({
     if (sectionState === 'REMINDER_CONFIRMATION_CLOSED') {
         return (
             <div css={buttonWrapperStyles}>
-                <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} />
+                <PrimaryButton
+                    buttonText={buttonText}
+                    buttonUrl={buttonUrl}
+                    trackClick={trackClick}
+                />
 
                 <PaymentIcons />
             </div>
@@ -135,12 +146,15 @@ export const ContributionsEpicButtons = ({
 
     return (
         <div css={buttonWrapperStyles}>
-            <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} />
+            <PrimaryButton buttonText={buttonText} buttonUrl={buttonUrl} trackClick={trackClick} />
 
             {remindMeButtonText && remindMeConfirmationText && (
                 <RemindMeButton
                     remindMeButtonText={remindMeButtonText}
-                    onClick={() => setSectionState('REMINDER_CONFIRMED')}
+                    onClick={() => {
+                        trackClick(REMIND_ME_BUTTON_INTERNAL_ID);
+                        setSectionState('REMINDER_CONFIRMED');
+                    }}
                 />
             )}
 

--- a/src/Epic/index.stories.tsx
+++ b/src/Epic/index.stories.tsx
@@ -126,10 +126,6 @@ WithReminderStory.args = {
         '... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
     paragraph2:
         'The Guardian will engage with the most critical issues of our time – from the escalating climate catastrophe to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
-    paragraph3:
-        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
-    paragraph4:
-        'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable. ',
     highlightedText:
         'Support <a href="https://example.com">The Guardian</a> from as little as %%CURRENCY_SYMBOL%%1 - and it only takes a minute. Thank you.',
     buttonText: 'Support The Guardian',

--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -5,6 +5,7 @@ import { ContributionsEpicButtons } from './ContributionsEpicButtons';
 import { COMPONENT_NAME, canRender, parseParagraphs } from './canRender';
 export { COMPONENT_NAME };
 import { replaceNonArticleCountPlaceholders } from './placeholders';
+import { TrackClick } from '../utils/tracking';
 
 // Custom styles for <a> tags in the Epic content
 const linkStyles = css`
@@ -71,6 +72,7 @@ export type EpicProps = {
     brazeMessageProps: BrazeMessageProps;
     countryCode?: string;
     headerSection?: React.ReactNode;
+    trackClick: TrackClick;
 };
 
 export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
@@ -83,9 +85,11 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
             remindMeButtonText,
             remindMeConfirmationHeaderText,
             remindMeConfirmationText,
+            ophanComponentId,
         },
         countryCode,
         headerSection,
+        trackClick,
     } = props;
 
     if (!canRender(props.brazeMessageProps)) {
@@ -123,6 +127,12 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                         remindMeButtonText={remindMeButtonText}
                         remindMeConfirmationText={remindMeConfirmationText}
                         remindMeConfirmationHeaderText={remindMeConfirmationHeaderText}
+                        trackClick={(buttonId: number) =>
+                            trackClick({
+                                internalButtonId: buttonId,
+                                ophanComponentId: ophanComponentId as string,
+                            })
+                        }
                     ></ContributionsEpicButtons>
                 </section>
             </div>

--- a/src/NewsletterEpic/index.test.tsx
+++ b/src/NewsletterEpic/index.test.tsx
@@ -28,8 +28,7 @@ describe('NewsletterEpic', () => {
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
-                    logButtonClickWithBraze={noOpClickHandler}
-                    submitComponentEvent={noOpClickHandler}
+                    trackClick={noOpClickHandler}
                 />,
             );
 
@@ -39,30 +38,23 @@ describe('NewsletterEpic', () => {
             expect(subscribeToNewsletter).toHaveBeenCalledWith(newsletterId);
         });
 
-        it('reports clicks to Ophan and Braze with the correct ID', async () => {
+        it('reports clicks with the correct ID', async () => {
             const subscribeToNewsletter = () => Promise.resolve();
-            const logButtonClickWithBraze = jest.fn();
-            const submitComponentEvent = jest.fn();
+            const trackClick = jest.fn();
             render(
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
-                    logButtonClickWithBraze={logButtonClickWithBraze}
-                    submitComponentEvent={submitComponentEvent}
+                    trackClick={trackClick}
                 />,
             );
 
             fireEvent.click(screen.getByText('Sign up'));
             await screen.findByText(/Thank you/);
 
-            expect(logButtonClickWithBraze).toHaveBeenCalledWith(0);
-            expect(submitComponentEvent).toHaveBeenCalledWith({
-                component: {
-                    componentType: 'RETENTION_EPIC',
-                    id: brazeMessageProps.ophanComponentId,
-                },
-                action: 'CLICK',
-                value: '1',
+            expect(trackClick).toHaveBeenCalledWith({
+                internalButtonId: 0,
+                ophanComponentId: 'ophan_component_id',
             });
         });
 
@@ -75,8 +67,7 @@ describe('NewsletterEpic', () => {
                 <NewsletterEpic
                     brazeMessageProps={brazeMessageProps}
                     subscribeToNewsletter={subscribeToNewsletter}
-                    logButtonClickWithBraze={noOpClickHandler}
-                    submitComponentEvent={noOpClickHandler}
+                    trackClick={noOpClickHandler}
                 />,
             );
 

--- a/src/UKNewsletterEpic/index.tsx
+++ b/src/UKNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const newsletterId = '4156';
 
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const UKNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/USNewsletterEpic/index.tsx
+++ b/src/USNewsletterEpic/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { canRender, COMPONENT_NAME } from './canRender';
 import { NewsletterEpic, NewsletterSubscribeCallback } from '../NewsletterEpic';
-import type { BrazeClickHandler } from '../utils/tracking';
-import type { OphanComponentEvent } from '@guardian/libs';
+import type { TrackClick } from '../utils/tracking';
 
 const IMAGE_URL =
     'https://i.guim.co.uk/img/media/d0944e021b1cc7426f515fecc8034f12b7862041/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=cca73e857c5093f39ef7a2a9dc2e7ce7';
@@ -20,8 +19,7 @@ export type BrazeMessageProps = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     subscribeToNewsletter: NewsletterSubscribeCallback;
-    logButtonClickWithBraze: BrazeClickHandler;
-    submitComponentEvent: (componentEvent: OphanComponentEvent) => void;
+    trackClick: TrackClick;
 };
 
 export const USNewsletterEpic: React.FC<Props> = (props: Props) => {

--- a/src/buildBrazeMessageComponent.test.tsx
+++ b/src/buildBrazeMessageComponent.test.tsx
@@ -6,15 +6,25 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { buildBrazeMessageComponent } from './buildBrazeMessageComponent';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noOp = () => {};
+
 describe('buildBrazeMessageComponent', () => {
     it('renders the correct component when a valid componentName is passed', () => {
         const ExampleComponent = jest.fn(() => null);
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         const mappings = {
             ExampleComponent,
         };
-        const BrazeMessageComponent = buildBrazeMessageComponent(mappings);
+        const BrazeMessageComponent = buildBrazeMessageComponent('RETENTION_EPIC', mappings);
 
-        render(<BrazeMessageComponent componentName={'ExampleComponent'} />);
+        render(
+            <BrazeMessageComponent
+                componentName={'ExampleComponent'}
+                logButtonClickWithBraze={noOp}
+                submitComponentEvent={noOp}
+            />,
+        );
 
         expect(ExampleComponent).toHaveBeenCalled();
     });
@@ -24,9 +34,15 @@ describe('buildBrazeMessageComponent', () => {
         const mappings = {
             ExampleComponent,
         };
-        const BrazeMessageComponent = buildBrazeMessageComponent(mappings);
+        const BrazeMessageComponent = buildBrazeMessageComponent('RETENTION_EPIC', mappings);
 
-        render(<BrazeMessageComponent componentName={'NoSuchComponent'} />);
+        render(
+            <BrazeMessageComponent
+                componentName={'NoSuchComponent'}
+                logButtonClickWithBraze={noOp}
+                submitComponentEvent={noOp}
+            />,
+        );
 
         expect(ExampleComponent).not.toHaveBeenCalled();
     });

--- a/src/buildBrazeMessageComponent.tsx
+++ b/src/buildBrazeMessageComponent.tsx
@@ -1,15 +1,32 @@
 import React from 'react';
+import type { BrazeClickHandler, SubmitComponentEvent, TrackClick } from './utils/tracking';
+import { buildTrackClick, OphanComponentType } from './utils/tracking';
 
 interface HasComponentName {
     componentName: string;
+}
+
+interface HasClickTrackingCallbacks {
+    logButtonClickWithBraze: BrazeClickHandler;
+    submitComponentEvent: SubmitComponentEvent;
+}
+
+export interface HasConsolidatedTrackClick {
+    trackClick: TrackClick;
 }
 
 export type ComponentMapping<A> = {
     [key: string]: React.FC<A>;
 };
 
-export function buildBrazeMessageComponent<A extends HasComponentName>(
-    mappings: ComponentMapping<A>,
+// We know in here that we have access to logButtonClickWithBraze and
+// submitComponentEvent (using the HasClickTrackingCallbacks interface). So,
+// we're able to consolidate these into a single trackClick callback in the
+// underlying component(s), as specified by the HasConsolidatedTrackClick
+// interface.
+export function buildBrazeMessageComponent<A extends HasComponentName & HasClickTrackingCallbacks>(
+    ophanComponentType: OphanComponentType,
+    mappings: ComponentMapping<A & HasConsolidatedTrackClick>,
 ): React.FC<A> {
     const BrazeMessageComponent = (props: A) => {
         const ComponentToRender = mappings[props.componentName];
@@ -18,7 +35,18 @@ export function buildBrazeMessageComponent<A extends HasComponentName>(
             return null;
         }
 
-        return <ComponentToRender {...props} />;
+        const trackClick = buildTrackClick({
+            submitComponentEvent: props.submitComponentEvent,
+            logButtonClickWithBraze: props.logButtonClickWithBraze,
+            ophanComponentType,
+        });
+
+        const augmentedProps = {
+            ...props,
+            trackClick,
+        };
+
+        return <ComponentToRender {...augmentedProps} />;
     };
 
     return BrazeMessageComponent;

--- a/src/utils/tracking.test.tsx
+++ b/src/utils/tracking.test.tsx
@@ -1,0 +1,68 @@
+import { buildTrackClick } from './tracking';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noOpCallback = () => {};
+
+describe('buildTrackClick', () => {
+    it('returns a function which calls submitComponentEvent with the correct args', () => {
+        const ophanComponentType = 'RETENTION_EPIC';
+        const submitComponentEvent = jest.fn();
+        const logButtonClickWithBraze = noOpCallback;
+        const trackClick = buildTrackClick({
+            ophanComponentType,
+            submitComponentEvent,
+            logButtonClickWithBraze,
+        });
+
+        const internalButtonId = 0;
+        const ophanComponentId = 'example_id';
+        trackClick({ ophanComponentId, internalButtonId });
+
+        expect(submitComponentEvent).toHaveBeenCalledWith({
+            action: 'CLICK',
+            component: {
+                componentType: ophanComponentType,
+                id: ophanComponentId,
+            },
+            // Braze displays the button id indexed from 1, so we add one when tracking in Ophan
+            // so that the values match:
+            value: '1',
+        });
+    });
+
+    it('returns a function which calls logButtonClickWithBraze with the correct args', () => {
+        const ophanComponentType = 'RETENTION_EPIC';
+        const submitComponentEvent = noOpCallback;
+        const logButtonClickWithBraze = jest.fn();
+        const trackClick = buildTrackClick({
+            ophanComponentType,
+            submitComponentEvent,
+            logButtonClickWithBraze,
+        });
+
+        const internalButtonId = 0;
+        const ophanComponentId = 'example_id';
+        trackClick({ ophanComponentId, internalButtonId });
+
+        expect(logButtonClickWithBraze).toHaveBeenCalledWith(internalButtonId);
+    });
+
+    it('catches errors in callbacks, so the other is not affected', () => {
+        const ophanComponentType = 'RETENTION_EPIC';
+        const submitComponentEvent = () => {
+            throw new Error('submitComponentEvent error!');
+        };
+        const logButtonClickWithBraze = jest.fn();
+        const trackClick = buildTrackClick({
+            ophanComponentType,
+            submitComponentEvent,
+            logButtonClickWithBraze,
+        });
+
+        const internalButtonId = 0;
+        const ophanComponentId = 'example_id';
+        trackClick({ ophanComponentId, internalButtonId });
+
+        expect(logButtonClickWithBraze).toHaveBeenCalled();
+    });
+});

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -1,3 +1,51 @@
-type BrazeClickHandler = (internalButtonId: number) => void;
+import type { OphanComponentEvent } from '@guardian/libs';
 
-export { BrazeClickHandler };
+type BrazeClickHandler = (internalButtonId: number) => void;
+type SubmitComponentEvent = (componentEvent: OphanComponentEvent) => void;
+
+type OphanComponentType = 'RETENTION_EPIC' | 'RETENTION_ENGAGEMENT_BANNER';
+
+type Props = {
+    submitComponentEvent: SubmitComponentEvent;
+    logButtonClickWithBraze: BrazeClickHandler;
+    ophanComponentType: OphanComponentType;
+};
+
+type InnerProps = {
+    ophanComponentId: string;
+    internalButtonId: number;
+};
+
+type TrackClick = (innerProps: InnerProps) => void;
+
+const catchAndLogErrors = (description: string, fn: () => void): void => {
+    try {
+        fn();
+    } catch (e) {
+        console.log(`Error (${description}): `, e.message);
+    }
+};
+
+const buildTrackClick =
+    ({ submitComponentEvent, logButtonClickWithBraze, ophanComponentType }: Props): TrackClick =>
+    ({ internalButtonId, ophanComponentId }: InnerProps) => {
+        catchAndLogErrors('ophanButtonClick', () => {
+            // Braze displays button id from 1, but internal representation is numbered from 0
+            // This ensures that the Button ID in Braze and Ophan will be the same
+            const externalButtonId = internalButtonId + 1;
+            submitComponentEvent({
+                component: {
+                    componentType: ophanComponentType,
+                    id: ophanComponentId,
+                },
+                action: 'CLICK',
+                value: externalButtonId.toString(10),
+            });
+        });
+
+        catchAndLogErrors('brazeButtonClick', () => {
+            logButtonClickWithBraze(internalButtonId);
+        });
+    };
+
+export { BrazeClickHandler, SubmitComponentEvent, TrackClick, OphanComponentType, buildTrackClick };


### PR DESCRIPTION
## What does this change?

This PR builds on #303 by wiring up the tracking on the Remind Me button (which is essential, so that we can know to schedule the email in Braze when a user clicks).

I was finding that the detail of all of our underlying components knowing about `submitComponentEvent` (Ophan) and the Braze tracking callback, which are both provided by the platform, a bit unwieldy. The underlying components always just trigger both, and that logic was duplicated in multiple places. More importantly, I don't think the underlying components should care about this level of detail.

So this PR also includes a refactoring where the higher-level entry component for each slot (`BrazeEndOfArticleComponent` and `BrazeBannerComponent`) takes the two click handling functions and combines them into a single callback `trackClick` which is passed to the individual components. So far I've only made us of this for epic components, but we can follow up in another PR to do this for banners.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
