### PR TITLE
Change Remind Me confirmation text

### DIFF
--- a/src/Epic/RemindMeConfirmation.tsx
+++ b/src/Epic/RemindMeConfirmation.tsx
@@ -70,10 +70,12 @@ export const RemindMeConfirmation = ({
                 <h4 css={successHeadingStyles}>{remindMeConfirmationHeaderText}</h4>
             )}
             <p css={successTextStyles}>
-                {remindMeConfirmationText} You can manage your email preferences in the My Account,{' '}
-                <a href="https://manage.theguardian.com/email-prefs">emails and marketing tab</a>.
-                If you have any questions about contributing, please{' '}
-                <a href="mailto:contribution.support@theguardian.com">contact us</a>.
+                {remindMeConfirmationText} You can manage your email preferences in the My Account
+                area,{' '}
+                <a href="https://manage.theguardian.com/email-prefs">
+                    emails and marketing section
+                </a>
+                .
             </p>
         </div>
     );


### PR DESCRIPTION
## What does this change?

This is a minor copy change. When a user clicks "Remind Me" on the Contribution epic there is a piece of dynamic text followed by a preset piece of content with links to our email preference management area. This PR changes that preset text and link.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

The content has changed in storybook, the link follows through to the correct place and the dynamic text is still changable.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/5294853/158959834-4e236c2f-7937-4c4f-b3e6-c133464314db.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
