### PR TITLE
Changed colour theme for the BannerWithLink

### DIFF
--- a/src/BannerWithLink/index.tsx
+++ b/src/BannerWithLink/index.tsx
@@ -1,17 +1,9 @@
 import React, { useState } from 'react';
-import { ThemeProvider } from '@emotion/react';
-import {
-    Button,
-    LinkButton,
-    SvgCross,
-    SvgInfo,
-    buttonThemeReaderRevenueBrandAlt,
-} from '@guardian/source-react-components';
+import { Button, LinkButton, SvgCross, SvgInfo } from '@guardian/source-react-components';
 import { OphanComponentEvent } from '@guardian/libs';
 
 import { BrazeClickHandler } from '../utils/tracking';
-import { styles as commonStyles } from '../styles/bannerCommon';
-import { overridenReaderRevenueTheme, styles } from './styles';
+import { styles } from '../styles/bannerCommon';
 import { canRender, COMPONENT_NAME } from './canRender';
 export { COMPONENT_NAME };
 
@@ -98,57 +90,53 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
     };
 
     return (
-        <div css={[commonStyles.wrapper, styles.wrapper]}>
-            <div css={commonStyles.contentContainer}>
-                <div css={commonStyles.topLeftComponent}>
-                    <div css={[commonStyles.infoIcon, styles.infoIcon]}>
+        <div css={[styles.wrapper, styles.wrapper]}>
+            <div css={styles.contentContainer}>
+                <div css={styles.topLeftComponent}>
+                    <div css={[styles.infoIcon, styles.infoIcon]}>
                         <SvgInfo />
                     </div>
-                    <div css={[commonStyles.heading, styles.heading]}>
-                        <span css={[commonStyles.smallInfoIcon, styles.infoIcon]}>
+                    <div css={[styles.heading, styles.heading]}>
+                        <span css={[styles.smallInfoIcon, styles.infoIcon]}>
                             <SvgInfo />
                         </span>
                         {header}
                     </div>
-                    <p css={[commonStyles.paragraph, styles.paragraph]}>
+                    <p css={[styles.paragraph, styles.paragraph]}>
                         {body}
 
                         {boldText ? (
                             <>
                                 <br />
-                                <strong css={[commonStyles.cta, styles.cta]}>{boldText}</strong>
+                                <strong css={[styles.cta, styles.cta]}>{boldText}</strong>
                             </>
                         ) : null}
                     </p>
-                    <ThemeProvider theme={overridenReaderRevenueTheme}>
-                        <LinkButton
-                            href={buttonUrl}
-                            css={commonStyles.primaryButton}
-                            onClick={() => onClick(0)}
-                        >
-                            {buttonText}
-                        </LinkButton>
-                    </ThemeProvider>
+                    <LinkButton
+                        href={buttonUrl}
+                        css={styles.primaryButton}
+                        onClick={() => onClick(0)}
+                    >
+                        {buttonText}
+                    </LinkButton>
                 </div>
-                <div css={[commonStyles.bottomRightComponent, styles.bottomRightComponent]}>
+                <div css={[styles.bottomRightComponent, styles.bottomRightComponent]}>
                     <div css={styles.image}>
                         <img src={imageUrl} alt="" />
                     </div>
-                    <div css={commonStyles.iconPanel}>
-                        <ThemeProvider theme={buttonThemeReaderRevenueBrandAlt}>
-                            <Button
-                                icon={<SvgCross />}
-                                hideLabel={true}
-                                cssOverrides={[commonStyles.closeButton, styles.closeButton]}
-                                priority="tertiary"
-                                size="small"
-                                aria-label="Close"
-                                onClick={(e) => onCloseClick(e, 1)}
-                                tabIndex={0}
-                            >
-                                {' '}
-                            </Button>
-                        </ThemeProvider>
+                    <div css={styles.iconPanel}>
+                        <Button
+                            icon={<SvgCross />}
+                            hideLabel={true}
+                            cssOverrides={[styles.closeButton, styles.closeButton]}
+                            priority="tertiary"
+                            size="small"
+                            aria-label="Close"
+                            onClick={(e) => onCloseClick(e, 1)}
+                            tabIndex={0}
+                        >
+                            {' '}
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -226,4 +226,27 @@ export const styles = {
             display: block;
         }
     `,
+    image: css`
+        max-width: 100%;
+        max-height: 300px;
+        display: flex;
+        justify-content: center;
+        align-items: flex-end;
+        margin-top: ${space[2]}px;
+
+        img {
+            max-width: 100%;
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+        }
+
+        ${until.desktop} {
+            display: none;
+        }
+
+        ${from.wide} {
+            margin-right: 100px;
+        }
+    `,
 };


### PR DESCRIPTION
## What does this change?

This change removes the orange colouring used for the Moment we were previously supporting. The colours are now defaulting to our standard grey.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
