### PR TITLE
Content cards spike

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 A library of React components for displaying Braze messages on DCR and
 frontend.
 
+Braze messages are exposed in two ways to address two separate use cases.
+
+1. One-shot messages
+2. Persistent notifications
+
+One-shot messages use
+[Braze's in-app messages](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/in-app_messaging/overview/)
+to show a user a single message impression. This is analagous to an ad
+impression. As with ads, these messages are often competing with other
+systems for shared message slots on the page. These messages are exposed
+by the [BrazeMessages](src/logic/BrazeMessages.tsx) class.
+
+Persistent notifications are backed by
+[Braze content cards](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/content_cards/data_models/).
+These notifications persist until they are dismissed (automatically or by
+the user), or they expire. Notifications from different sources can
+peacfully co-exist. These notifications are exposed by the
+[BrazeCards](src/logic/BrazeCards.ts) class.
+
 ## Development
 
 ### Local Setup

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "rollup -c",
     "postbuild": "tsc --project tsconfig.types.json",
     "test": "jest",
+    "testwatch": "jest --watch",
     "tsc": "tsc  --noEmit",
     "prerelease": "yarn build",
     "release": "np",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
+    "fast-check": "^2.24.0",
     "jest": "^26.4.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "nanoevents": "5.1.10",

--- a/src/logic/BrazeCards.test.ts
+++ b/src/logic/BrazeCards.test.ts
@@ -1,0 +1,247 @@
+import fc from 'fast-check';
+import appboy from '@braze/web-sdk-core';
+import { BrazeCard, BrazeCards } from './BrazeCards';
+import { CardSlotName, Extras } from './types';
+
+function errorHandler(error: Error, identifier: string): void {
+    console.log(identifier, error);
+}
+
+describe('braze content cards', () => {
+    describe('BrazeCards', () => {
+        describe('getCardsForProfileBadge', () => {
+            test('returns empty array if there are no content cards for this user', () => {
+                jest.spyOn(appboy, 'getCachedContentCards').mockImplementation(() => {
+                    return new appboy.ContentCards([], new Date());
+                });
+                const brazeCards = new BrazeCards(appboy, errorHandler);
+                const result = brazeCards.getCardsForProfileBadge();
+                expect(result).toEqual([]);
+            });
+
+            test("returns BrazeCard instances for each of the profile badge cards in the user's cached card feed", () => {
+                jest.spyOn(appboy, 'getCachedContentCards').mockImplementation(() => {
+                    return new appboy.ContentCards(
+                        [
+                            testCard('ProfileBadge', 'card-id-1', { field1: 'value-1' }),
+                            testCard('ProfileBadge', 'card-id-2', { field1: 'another-value' }),
+                            testCard('ProfileBadge', 'card-id-3', { field2: 'yet-another-value' }),
+                        ],
+                        new Date(),
+                    );
+                });
+                const brazeCards = new BrazeCards(appboy, errorHandler);
+                const result = brazeCards.getCardsForProfileBadge();
+                const cardIds = result.map((card) => card.id);
+                expect(cardIds).toEqual(['card-id-1', 'card-id-2', 'card-id-3']);
+            });
+
+            test("uses Braze's card ID", () => {
+                fc.assert(
+                    fc.property(fc.string(), (id) => {
+                        jest.spyOn(appboy, 'getCachedContentCards').mockImplementation(() => {
+                            return new appboy.ContentCards(
+                                [testCard('ProfileBadge', id, {})],
+                                new Date(),
+                            );
+                        });
+                        const brazeCards = new BrazeCards(appboy, errorHandler);
+                        const result = brazeCards.getCardsForProfileBadge();
+                        expect(result[0].id).toEqual(id);
+                    }),
+                );
+            });
+
+            test('uses the extras record that Braze provides', () => {
+                const extrasGen = fc.dictionary(fc.string(), fc.string());
+                fc.assert(
+                    fc.property(extrasGen, (dict) => {
+                        const extras = { ...dict, slotName: 'ProfileBadge' };
+                        jest.spyOn(appboy, 'getCachedContentCards').mockImplementation(() => {
+                            return new appboy.ContentCards(
+                                [testCard('ProfileBadge', 'card-id', dict)],
+                                new Date(),
+                            );
+                        });
+                        const brazeCards = new BrazeCards(appboy, errorHandler);
+                        const result = brazeCards.getCardsForProfileBadge();
+                        expect(result[0].extras).toEqual(extras);
+                    }),
+                );
+            });
+
+            test('returns no control cards if the cached feed contains only unsupported cards', () => {
+                // cards with no extras or missing the slotName, so they cannot be handled by this library
+                jest.spyOn(appboy, 'getCachedContentCards').mockImplementation(() => {
+                    return new appboy.ContentCards(
+                        [
+                            // a card for an unsupported slot
+                            testCard('AnotherSlotName', 'card-id-another-slot', {}),
+                            // a card that does not contain a slotname
+                            new appboy.ControlCard(
+                                'card-id-no-slotname',
+                                false,
+                                new Date(),
+                                new Date(new Date().getTime() + 86400),
+                                { extraField: 'field-value' },
+                                false,
+                            ),
+                        ],
+                        new Date(),
+                    );
+                });
+                const brazeCards = new BrazeCards(appboy, errorHandler);
+                const result = brazeCards.getCardsForProfileBadge();
+                expect(result).toEqual([]);
+            });
+        });
+
+        test("The last updated date comes from the appboy instance's last updated date", () => {
+            fc.assert(
+                fc.property(fc.date(), (date) => {
+                    jest.spyOn(appboy, 'getCachedContentCards').mockImplementation(() => {
+                        return new appboy.ContentCards([], date);
+                    });
+                    const brazeCards = new BrazeCards(appboy, errorHandler);
+                    expect(brazeCards.lastUpdated).toEqual(date);
+                }),
+            );
+        });
+    });
+
+    describe('BrazeCard', () => {
+        test('logImpression calls the appboy sdk method', () => {
+            const mockAppboyFn = jest.fn();
+            const mockErrorHandler = jest.fn();
+            const appboyCard = testCard('ProfileBadge', 'card-id', {});
+            jest.spyOn(appboy, 'logCardImpressions').mockImplementation((cards) => {
+                mockAppboyFn(cards);
+                return true;
+            });
+            const brazeCard = new BrazeCard(
+                'card-id',
+                'ProfileBadge',
+                appboyCard,
+                appboy,
+                mockErrorHandler,
+            );
+
+            brazeCard.logImpression();
+
+            expect(mockAppboyFn).toHaveBeenCalledWith([appboyCard]);
+            expect(mockErrorHandler).toHaveBeenCalledTimes(0);
+        });
+
+        test('logImpression fails if the appboy sdk method fails (returns false)', () => {
+            const mockErrorHandler = jest.fn();
+            const appboyCard = testCard('ProfileBadge', 'card-id', {});
+            jest.spyOn(appboy, 'logCardImpressions').mockImplementation(() => {
+                return false;
+            });
+            const brazeCard = new BrazeCard(
+                'card-id',
+                'ProfileBadge',
+                appboyCard,
+                appboy,
+                mockErrorHandler,
+            );
+
+            brazeCard.logImpression();
+
+            expect(mockErrorHandler).toHaveBeenCalled();
+        });
+
+        test('logCardClick calls the appboy sdk method', () => {
+            const mockAppboyFn = jest.fn();
+            const mockErrorHandler = jest.fn();
+            const appboyCard = testCard('ProfileBadge', 'card-id', {});
+            jest.spyOn(appboy, 'logCardClick').mockImplementation((card) => {
+                mockAppboyFn(card);
+                return true;
+            });
+            const brazeCard = new BrazeCard(
+                'card-id',
+                'ProfileBadge',
+                appboyCard,
+                appboy,
+                mockErrorHandler,
+            );
+
+            brazeCard.logCardClick();
+
+            expect(mockAppboyFn).toHaveBeenCalledWith(appboyCard);
+            expect(mockErrorHandler).toHaveBeenCalledTimes(0);
+        });
+
+        test('logCardClick fails if the appboy sdk method fails (returns false)', () => {
+            const mockErrorHandler = jest.fn();
+            const appboyCard = testCard('ProfileBadge', 'card-id', {});
+            jest.spyOn(appboy, 'logCardClick').mockImplementation(() => {
+                return false;
+            });
+            const brazeCard = new BrazeCard(
+                'card-id',
+                'ProfileBadge',
+                appboyCard,
+                appboy,
+                mockErrorHandler,
+            );
+
+            brazeCard.logCardClick();
+
+            expect(mockErrorHandler).toHaveBeenCalled();
+        });
+
+        test('logCardDismissal calls the appboy sdk method', () => {
+            const mockAppboyFn = jest.fn();
+            const mockErrorHandler = jest.fn();
+            const appboyCard = testCard('ProfileBadge', 'card-id', {});
+            jest.spyOn(appboy, 'logCardDismissal').mockImplementation((card) => {
+                mockAppboyFn(card);
+                return true;
+            });
+            const brazeCard = new BrazeCard(
+                'card-id',
+                'ProfileBadge',
+                appboyCard,
+                appboy,
+                mockErrorHandler,
+            );
+
+            brazeCard.logCardDismissal();
+
+            expect(mockAppboyFn).toHaveBeenCalledWith(appboyCard);
+            expect(mockErrorHandler).toHaveBeenCalledTimes(0);
+        });
+
+        test('logCardDismissal fails if the appboy sdk method fails (returns false)', () => {
+            const mockErrorHandler = jest.fn();
+            const appboyCard = testCard('ProfileBadge', 'card-id', {});
+            jest.spyOn(appboy, 'logCardDismissal').mockImplementation(() => {
+                return false;
+            });
+            const brazeCard = new BrazeCard(
+                'card-id',
+                'ProfileBadge',
+                appboyCard,
+                appboy,
+                mockErrorHandler,
+            );
+
+            brazeCard.logCardDismissal();
+
+            expect(mockErrorHandler).toHaveBeenCalled();
+        });
+    });
+});
+
+function testCard(slotName: CardSlotName | string, id: string, extras: Extras): appboy.ControlCard {
+    return new appboy.ControlCard(
+        id,
+        false,
+        new Date(),
+        new Date(new Date().getTime() + 86400),
+        { ...extras, slotName: slotName },
+        false,
+    );
+}

--- a/src/logic/BrazeCards.ts
+++ b/src/logic/BrazeCards.ts
@@ -1,0 +1,158 @@
+import appboy from '@braze/web-sdk-core';
+import { ErrorHandler, Extras, CardSlotName, CardSlotNames } from './types';
+
+interface BrazeCardsInterface {
+    getCardsForProfileBadge: () => BrazeCard[];
+}
+
+class BrazeCard {
+    id: string;
+
+    slotName: CardSlotName;
+
+    private card: appboy.ControlCard;
+
+    private appboy: typeof appboy;
+
+    private errorHandler: ErrorHandler;
+
+    constructor(
+        id: string,
+        slotName: CardSlotName,
+        card: appboy.ControlCard,
+        appboyInstance: typeof appboy,
+        errorHandler: ErrorHandler,
+    ) {
+        this.id = id;
+        this.slotName = slotName;
+        this.card = card;
+        this.appboy = appboyInstance;
+        this.errorHandler = errorHandler;
+    }
+
+    logImpression(): void {
+        try {
+            const result = this.appboy.logCardImpressions([this.card]);
+            if (!result) {
+                this.errorHandler(
+                    new Error('Failed to log card impression event'),
+                    'BrazeCard.logImpressions',
+                );
+            }
+        } catch (error) {
+            this.errorHandler(error, 'BrazeCard.logImpressions');
+        }
+    }
+
+    logCardClick(): void {
+        try {
+            const result = this.appboy.logCardClick(this.card, true);
+            if (!result) {
+                this.errorHandler(
+                    new Error('Failed to log card click event'),
+                    'BrazeCard.logCardClick',
+                );
+            }
+        } catch (error) {
+            this.errorHandler(error, 'BrazeCard.logCardClick');
+        }
+    }
+
+    logCardDismissal(): void {
+        try {
+            const result = this.appboy.logCardDismissal(this.card);
+            if (!result) {
+                this.errorHandler(
+                    new Error('Failed to log card dismiss event'),
+                    'BrazeCard.logCardDismiss',
+                );
+            }
+        } catch (error) {
+            this.errorHandler(error, 'BrazeCard.logCardDismiss');
+        }
+    }
+
+    /**
+     * Returns the card's key/value pairs.
+     *
+     * We know this can't be empty because there must have been at least a `slotName`
+     * field present to be able to generate the card.
+     */
+    get extras(): Extras {
+        const data = this.card.extras;
+        // since empty extras is impossible, let's add this case to eliminate undefined from the type
+        if (data === undefined) {
+            return {};
+        } else {
+            return data;
+        }
+    }
+
+    get expiry(): Date | undefined {
+        const expiryDate = this.card.expiresAt;
+        if (expiryDate === null) {
+            return undefined;
+        } else {
+            return expiryDate;
+        }
+    }
+}
+
+class BrazeCards implements BrazeCardsInterface {
+    appboy: typeof appboy;
+
+    errorHandler: ErrorHandler;
+
+    constructor(appboyInstance: typeof appboy, errorHandler: ErrorHandler) {
+        this.appboy = appboyInstance;
+        this.errorHandler = errorHandler;
+    }
+
+    getCardsForProfileBadge(): BrazeCard[] {
+        return this.getCardsForSlot(CardSlotNames.ProfileBadge);
+    }
+
+    private getCardsForSlot(targetSlotName: CardSlotName): BrazeCard[] {
+        const cachedCards = this.appboy.getCachedContentCards().cards.flatMap((appboyCard) => {
+            if (appboyCard instanceof appboy.ControlCard) {
+                const { extras } = appboyCard;
+
+                if (extras && extras.slotName && extras.slotName === targetSlotName) {
+                    if (appboyCard.id === undefined) {
+                        this.errorHandler(
+                            new Error('appboy card had no ID'),
+                            'BrazeCards.getCardsForSlot',
+                        );
+                        return [];
+                    } else {
+                        return [
+                            new BrazeCard(
+                                appboyCard.id,
+                                targetSlotName,
+                                appboyCard,
+                                appboy,
+                                this.errorHandler,
+                            ),
+                        ];
+                    }
+                } else {
+                    // TODO: Consider whether this an error state, or something we're happy to ignore
+                    //       Will there be other content cards in users' feeds that we should ignore?
+                    return [];
+                }
+            } else {
+                // TODO: Consider whether this an error state, or something we're happy to ignore
+                //       Will there be other content cards in users' feeds that we should ignore?
+                return [];
+            }
+        });
+
+        return cachedCards;
+    }
+
+    get lastUpdated(): Date | null {
+        return this.appboy.getCachedContentCards().lastUpdated;
+    }
+}
+
+export { BrazeCard, BrazeCards };

--- a/src/logic/BrazeMessages.tsx
+++ b/src/logic/BrazeMessages.tsx
@@ -2,11 +2,8 @@
 
 import type appboy from '@braze/web-sdk-core';
 import { MessageCache, MessageWithId } from './LocalMessageCache';
-import type { SlotName } from './types';
+import type { ErrorHandler, Extras, MessageSlotName } from './types';
 import { canRenderBrazeMsg } from '../canRender';
-
-export type Extras = Record<string, string>;
-export type ErrorHandler = (error: Error, identifier: string) => void;
 
 interface BrazeArticleContext {
     section?: string;
@@ -34,7 +31,7 @@ class BrazeMessage {
 
     message: appboy.HtmlMessage;
 
-    slotName: SlotName;
+    slotName: MessageSlotName;
 
     cache: MessageCache;
 
@@ -44,7 +41,7 @@ class BrazeMessage {
         id: string,
         message: appboy.HtmlMessage,
         appboyInstance: typeof appboy,
-        slotName: SlotName,
+        slotName: MessageSlotName,
         cache: MessageCache,
         errorHandler: ErrorHandler,
     ) {
@@ -91,7 +88,7 @@ class BrazeMessage {
 class BrazeMessages implements BrazeMessagesInterface {
     appboy: typeof appboy;
 
-    freshMessageBySlot: Record<SlotName, Promise<appboy.HtmlMessage>>;
+    freshMessageBySlot: Record<MessageSlotName, Promise<appboy.HtmlMessage>>;
 
     cache: MessageCache;
 
@@ -109,7 +106,7 @@ class BrazeMessages implements BrazeMessagesInterface {
 
     // Generally we only expect a single message per slot max in a pageview. This method
     // returns a promise which will resolve when the first message arrives
-    private getFreshMessagesForSlot(targetSlotName: SlotName): Promise<appboy.HtmlMessage> {
+    private getFreshMessagesForSlot(targetSlotName: MessageSlotName): Promise<appboy.HtmlMessage> {
         return new Promise((resolve) => {
             const callback = (m: appboy.InAppMessage | appboy.ControlMessage) => {
                 // Cast this as we only ever expect it to be an HtmlMessage (subclass of InAppMessage)
@@ -142,7 +139,7 @@ class BrazeMessages implements BrazeMessagesInterface {
         return this.getMessageForSlot('EndOfArticle', articleContext);
     }
 
-    private getMessageForSlot(slotName: SlotName, articleContext?: BrazeArticleContext) {
+    private getMessageForSlot(slotName: MessageSlotName, articleContext?: BrazeArticleContext) {
         // If there's already a message in the cache, return it
         const firstRenderableMessage = this.getHighestPriorityMessageFromCache(
             slotName,
@@ -171,7 +168,7 @@ class BrazeMessages implements BrazeMessagesInterface {
     }
 
     private getHighestPriorityMessageFromCache(
-        slotName: SlotName,
+        slotName: MessageSlotName,
         articleContext?: BrazeArticleContext,
     ) {
         const messagesFromCache = this.cache.all(slotName, this.appboy, this.errorHandler);

--- a/src/logic/LocalMessageCache.test.ts
+++ b/src/logic/LocalMessageCache.test.ts
@@ -7,7 +7,7 @@ import {
     hydrateMessage,
     MessageData,
 } from './LocalMessageCache';
-import type { SlotName } from './types';
+import type { MessageSlotName } from './types';
 
 const message1Json = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 1","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
 const message2Json = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 2","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
@@ -20,7 +20,7 @@ beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
 });
 
-const getQueueSizeFor = (slotName: SlotName): number => {
+const getQueueSizeFor = (slotName: MessageSlotName): number => {
     const queue = storage.local.get(`gu.brazeMessageCache.${slotName}`) as CachedMessage[];
 
     return queue.length;

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -1,8 +1,17 @@
-enum SlotNames {
+type Extras = Record<string, string>;
+type ErrorHandler = (error: Error, identifier: string) => void;
+
+// slots that support one-shot messages (using Braze's in-app messages)
+enum MessageSlotNames {
     Banner = 'Banner',
     EndOfArticle = 'EndOfArticle',
 }
+type MessageSlotName = keyof typeof MessageSlotNames;
 
-type SlotName = keyof typeof SlotNames;
+// slots that support persistent notifications (using Braze content cards)
+enum CardSlotNames {
+    ProfileBadge = 'ProfileBadge', // example slot for now
+}
+type CardSlotName = keyof typeof CardSlotNames;
 
-export { SlotNames, SlotName };
+export { Extras, ErrorHandler, MessageSlotNames, MessageSlotName, CardSlotNames, CardSlotName };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7095,6 +7095,13 @@ fake-tag@^2.0.0:
   resolved "https://registry.yarnpkg.com/fake-tag/-/fake-tag-2.0.0.tgz#08ea5df950ef8635833186247f569e8406ffb4da"
   integrity sha512-QDz+8qiNQ9AfBZ31EXlID5JIbUkU3e1nXDWk4tidFzd2gy8XJaEUW1HCuDY6DUy6t2Y0nvhD6PsUc+2WYy5w0w==
 
+fast-check@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.24.0.tgz#39f85586862108a4de6394c5196ebcf8b76b6c8b"
+  integrity sha512-iNXbN90lbabaCUfnW5jyXYPwMJLFYl09eJDkXA9ZoidFlBK63gNRvcKxv+8D1OJ1kIYjwBef4bO/K3qesUeWLQ==
+  dependencies:
+    pure-rand "^5.0.1"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -12034,6 +12041,11 @@ puppeteer-core@^2.1.1:
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
     ws "^6.1.0"
+
+pure-rand@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-5.0.1.tgz#97a287b4b4960b2a3448c0932bf28f2405cac51d"
+  integrity sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==
 
 qs@6.7.0:
   version "6.7.0"


### PR DESCRIPTION
## What does this change?

BrazeCards is a mechanism for providing persistent 'notification' messages, in contrast to the existing single-impression (In-App-Message backed) BrazeMessages behaviour.

This PR introduces the basic abstraction for content cards, without providing any specific slot component. BrazeCards looks very similar to BrazeMessages, but exposes a different interface.

- it returns collections of cards for the given slot, instead of selecting a single message
- Braze's SDK serves cards out its own cache, so there's no need to return a `promise`
- the above means we can also skip our own cache implementation

This change also splits the representation of 'slots' into `MessageSlot`s and `CardSlot`s. This change encodes in the types the distinction between slots which will display the single highest-priority message (if available), versus those that are able to prompt the user on multiple counts simultaneously.

I expect in the future we'd consider setting up notification slots to support multiple message streams of differeing priority, but this is something we should add as we develop a better intuition of how this feature will be used. Well-considered [prior art](https://developer.android.com/training/notify-user/channels) exists for these features, when the need arises.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This draft includes tests, but the next step is to do some work exploring the DCR integration.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We won't be able to say this is a success until we have created a real slot on the page and started running tests using this card mechanism.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This will slightly increase the bundle size of this library's 'core'. Other risks are minimal for now, before we've integrated this with a real slot on the site.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

N/A
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

N/A
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
