### PR TITLE
Storybook Multi-section Filter

### DIFF
--- a/.storybook/article-context/ArticleContextPanel.tsx
+++ b/.storybook/article-context/ArticleContextPanel.tsx
@@ -95,7 +95,7 @@ export const nonEmotionStyles: Record<string, React.CSSProperties> = {
 };
 
 export const ArticleContextPanel = ({ active, api }: Props) => {
-    const [selectedSection, setSelectedSection] = useState('');
+    const [selectedSections, setSelectedSections] = useState<string[]>([]);
 
     const inputRef = useRef<HTMLInputElement>();
 
@@ -126,11 +126,20 @@ export const ArticleContextPanel = ({ active, api }: Props) => {
                         <td style={nonEmotionStyles.td}>
                             <select
                                 id="section-dropdown"
-                                onChange={(event) => setSelectedSection(event.target.value)}
+                                onChange={(event) => {
+                                    setSelectedSections(
+                                        [...event.target.selectedOptions].map(
+                                            (option) => option.value,
+                                        ),
+                                    );
+                                }}
                                 style={nonEmotionStyles.select}
+                                multiple
                             >
                                 {guardianSectionIds.map((id) => (
-                                    <option value={id}>{id}</option>
+                                    <option key={id} value={id}>
+                                        {id}
+                                    </option>
                                 ))}
                             </select>
                         </td>
@@ -143,9 +152,10 @@ export const ArticleContextPanel = ({ active, api }: Props) => {
                             </button>
                             <input
                                 ref={inputRef}
-                                value={selectedSection}
+                                value={selectedSections.join('|')}
                                 style={nonEmotionStyles.textInput}
                                 placeholder="Select section from dropdown then copy it from here"
+                                readOnly
                             ></input>
                         </td>
                     </tr>

--- a/.storybook/article-context/ArticleContextPanel.tsx
+++ b/.storybook/article-context/ArticleContextPanel.tsx
@@ -100,9 +100,11 @@ export const ArticleContextPanel = ({ active, api }: Props) => {
     const inputRef = useRef<HTMLInputElement>();
 
     const onCopyClick = () => {
-        inputRef.current.select();
-        inputRef.current.setSelectionRange(0, 1000);
-        navigator.clipboard.writeText(inputRef.current.value);
+        if (inputRef?.current) {
+            inputRef.current.select();
+            inputRef.current.setSelectionRange(0, 1000);
+            navigator.clipboard.writeText(inputRef.current.value);
+        }
     };
 
     return (


### PR DESCRIPTION
## What does this change?

In #362 we added support for specifying that a message should appear on multiple sections (previously there was a limitation to a single section). This PR updates the storybook `Article Context Filters` tab to make it clear multiple sections are supported. When multiple sections are selected a pipe (`|`) separated list is generated which can be copy pasted into Braze.

In future it might be nice to use a fancier multi-select component, but for now I'm keeping it simple and going with the basic HTML version.

![2022-09-22 13 10 36](https://user-images.githubusercontent.com/379839/191743088-f202e4cc-1a6b-4271-a3d2-b90e7f0069ac.gif)