### PR TITLE
Close the banner when user presses the ESC key

### DIFF
--- a/src/AppBanner/index.tsx
+++ b/src/AppBanner/index.tsx
@@ -12,6 +12,7 @@ import { OphanComponentEvent } from '@guardian/libs';
 import { AppStore } from '../assets/app-store';
 import { PlayStore } from '../assets/play-store';
 import { BrazeClickHandler } from '../utils/tracking';
+import { useEscapeShortcut } from '../utils/useEscapeShortcut';
 import { styles as commonStyles } from '../styles/bannerCommon';
 import { styles } from './styles';
 
@@ -56,17 +57,18 @@ export const AppBanner = (props: Props): ReactElement | null => {
 
     const [showBanner, setShowBanner] = useState(true);
 
-    if (!showBanner) {
-        return null;
-    }
-
     const onCloseClick = (
         evt: React.MouseEvent<HTMLButtonElement, MouseEvent>,
         internalButtonId: number,
     ): void => {
         evt.preventDefault();
 
+        onCloseAction(internalButtonId);
+    };
+
+    const onCloseAction = (internalButtonId: number): void => {
         setShowBanner(false);
+        document.body.focus();
 
         catchAndLogErrors('ophanButtonClick', () => {
             // Braze displays button id from 1, but internal representation is numbered from 0
@@ -87,6 +89,8 @@ export const AppBanner = (props: Props): ReactElement | null => {
         });
     };
 
+    useEscapeShortcut(() => onCloseAction(1), []);
+
     // This is to keep button colors the same as before
     // https://github.com/guardian/braze-components/pull/123
     // Probably should be removed later
@@ -103,6 +107,10 @@ export const AppBanner = (props: Props): ReactElement | null => {
             textSubdued: 'rgb(51, 51, 51)',
         },
     };
+
+    if (!showBanner) {
+        return null;
+    }
 
     return (
         <div css={commonStyles.wrapper}>

--- a/src/BannerWithLink/index.tsx
+++ b/src/BannerWithLink/index.tsx
@@ -3,6 +3,7 @@ import { Button, LinkButton, SvgCross, SvgInfoRound } from '@guardian/source-rea
 import { OphanComponentEvent } from '@guardian/libs';
 
 import { BrazeClickHandler } from '../utils/tracking';
+import { useEscapeShortcut } from '../utils/useEscapeShortcut';
 import { styles } from '../styles/bannerCommon';
 import { canRender, COMPONENT_NAME } from './canRender';
 export { COMPONENT_NAME };
@@ -53,10 +54,6 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
         return null;
     }
 
-    if (!showBanner) {
-        return null;
-    }
-
     const logToBrazeAndOphan = (internalButtonId: number): void => {
         catchAndLogErrors('ophanButtonClick', () => {
             // Braze displays button id from 1, but internal representation is numbered from 0
@@ -83,11 +80,21 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
         internalButtonId: number,
     ): void => {
         evt.preventDefault();
+        onCloseAction(internalButtonId);
+    };
 
+    const onCloseAction = (internalButtonId: number): void => {
         setShowBanner(false);
+        document.body.focus();
 
         logToBrazeAndOphan(internalButtonId);
     };
+
+    useEscapeShortcut(() => onCloseAction(1), []);
+
+    if (!showBanner) {
+        return null;
+    }
 
     return (
         <div css={styles.wrapper}>

--- a/src/utils/useEscapeShortcut.ts
+++ b/src/utils/useEscapeShortcut.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+// Pass a function to run when the user hits the escape key
+// Useful for enabling a keyboard shortcut for dismissing banners
+export function useEscapeShortcut(
+    eventHandler: (event: KeyboardEvent) => void,
+    deps: React.DependencyList = [],
+): void {
+    function handleEscapeKeydown(event: KeyboardEvent) {
+        // IE key name is 'Esc', because IE
+        const isEscapeKey = event.key === 'Escape' || event.key === 'Esc';
+        if (isEscapeKey) {
+            eventHandler(event);
+        }
+    }
+
+    useEffect(() => {
+        window.addEventListener('keydown', handleEscapeKeydown);
+
+        return () => window.removeEventListener('keydown', handleEscapeKeydown);
+    }, deps);
+}


### PR DESCRIPTION
## What does this change?
Adds functionality which will allow users to close the Braze banner by pressing on the keyboard ESC key - this matches existing functionality for closing RRCP banners

The PR also includes a small fix to make the page focus revert to `document.body` when the user closes the banner.

### Testing
Test in Storybook by opening a banner then clicking on the ESC key