### PR TITLE
Fix margin CSS on epic body paragraphs

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -30,7 +30,7 @@ const styles = {
         flex-direction: column;
     `,
     paragraph: css`
-        margin: 0 auto ${space[2]}px;
+        margin-bottom: ${space[2]}px;
         ${body.medium()}
         ${linkStyles}
     `,


### PR DESCRIPTION
## What does this change?
A small styling fix to prevent short Epic body paragraphs centering themselves when they should be left-aligned

## How to test
Tested in Storybook by deliberately shortening paragraph copy.

The bug only effected default Epic components, not any of the other epics (verified in Storybook)

## Screenshots

**Before fix**
![Screenshot 2022-11-17 at 15 37 05](https://user-images.githubusercontent.com/5357530/202491661-013827fe-42b6-4621-87a8-4ebdeee19f1f.png)

**After fix**
![Screenshot 2022-11-17 at 15 37 45](https://user-images.githubusercontent.com/5357530/202491716-d64aafa5-e586-413f-ba95-63fc3ea60348.png)

