### PR TITLE
Fix bold in epic

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -28,6 +28,11 @@ const styles = {
         background-color: #f6f6f6;
         display: flex;
         flex-direction: column;
+
+        b,
+        strong {
+            font-weight: bold;
+        }
     `,
     paragraph: css`
         margin-top: 0;


### PR DESCRIPTION
The style of `<b>` tags is being overridden by DCR, causing them to have no effect.

We made a [similar change in SDC](https://github.com/guardian/support-dotcom-components/pull/806)