### PR TITLE
Log impressions as content cards

### DIFF
--- a/src/logic/BrazeCards.ts
+++ b/src/logic/BrazeCards.ts
@@ -32,7 +32,7 @@ class BrazeCard {
 
     logImpression(): void {
         try {
-            const result = this.appboy.logCardImpressions([this.card]);
+            const result = this.appboy.logCardImpressions([this.card], true);
             if (!result) {
                 this.errorHandler(
                     new Error('Failed to log card impression event'),


### PR DESCRIPTION
## What does this change?

The `logCardImpressions` method takes an optional second boolean argument. This determines whether to log the impression as a content card event (as opposed to a legacy news feed event, which is apparently a predecessor to content cards).