### PR TITLE
Bump `@guardian/source-react-components-development-kitchen` and `@guardian/libs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@guardian/libs": "^3.1.0",
     "@guardian/source-foundations": "^7.0.1",
     "@guardian/source-react-components": "^9.0.0",
-    "@guardian/source-react-components-development-kitchen": "^7.1.1",
+    "@guardian/source-react-components-development-kitchen": "^6.0.2 || ^7.1.1",
     "react": "17.0.2"
   },
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@guardian/node-riffraff-artifact": "^0.3.2",
     "@guardian/source-foundations": "^7.0.1",
     "@guardian/source-react-components": "^9.0.0",
-    "@guardian/source-react-components-development-kitchen": "5.0.0",
+    "@guardian/source-react-components-development-kitchen": "^7.1.1",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",
@@ -97,7 +97,7 @@
     "@guardian/libs": "^3.1.0",
     "@guardian/source-foundations": "^7.0.1",
     "@guardian/source-react-components": "^9.0.0",
-    "@guardian/source-react-components-development-kitchen": "5.0.0",
+    "@guardian/source-react-components-development-kitchen": "^7.1.1",
     "react": "17.0.2"
   },
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@emotion/react": "^11.1.2",
     "@guardian/eslint-plugin-source-react-components": "^9.0.0",
     "@guardian/grid-client": "^1.1.1",
-    "@guardian/libs": "^3.1.0",
+    "@guardian/libs": "^10.1.1",
     "@guardian/node-riffraff-artifact": "^0.3.2",
     "@guardian/source-foundations": "^7.0.1",
     "@guardian/source-react-components": "^9.0.0",
@@ -89,12 +89,13 @@
     "rollup-plugin-visualizer": "^4.1.1",
     "storybook": "^6.5.4",
     "ts-jest": "^28.0.3",
+    "tslib": "^2.4.1",
     "typescript": "^4.2.4",
     "wait-on": "^5.2.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/libs": "^3.1.0",
+    "@guardian/libs": "^7.1.4 || ^10.1.1",
     "@guardian/source-foundations": "^7.0.1",
     "@guardian/source-react-components": "^9.0.0",
     "@guardian/source-react-components-development-kitchen": "^6.0.2 || ^7.1.1",

--- a/src/Epic/RemindMeConfirmation.tsx
+++ b/src/Epic/RemindMeConfirmation.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import { body, from, headline, neutral, space } from '@guardian/source-foundations';
 import { Button, SvgCross } from '@guardian/source-react-components';
-import { Lines } from '@guardian/source-react-components-development-kitchen';
+import { StraightLines } from '@guardian/source-react-components-development-kitchen';
 
 const reminderConfirmationContainerStyles = css`
     position: relative;
@@ -65,7 +65,7 @@ export const RemindMeConfirmation = ({
                     Close
                 </Button>
             </div>
-            <Lines />
+            <StraightLines />
             {remindMeConfirmationHeaderText && (
                 <h4 css={successHeadingStyles}>{remindMeConfirmationHeaderText}</h4>
             )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,10 +1688,10 @@
     monocle-ts "^2.3.3"
     newtype-ts "^0.3.4"
 
-"@guardian/libs@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.1.0.tgz#44b0291741a0fce588167f4ec8c17fa9a7d41261"
-  integrity sha512-GJk34o9lUmP6FcBKd0FSV2RwvAKKJzcAV5mVdhgq/JmBNj8Ns5eiJlq8LG2ewIJJSzRaWT4h8Fg6n9KI8K0xDQ==
+"@guardian/libs@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
+  integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
 
 "@guardian/node-riffraff-artifact@^0.3.2":
   version "0.3.2"
@@ -14022,6 +14022,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,10 +1714,10 @@
   dependencies:
     mini-svg-data-uri "^1.3.3"
 
-"@guardian/source-react-components-development-kitchen@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-5.0.0.tgz#17fbe059bf70cd6dc3e09726373f8499f0cce80c"
-  integrity sha512-X/LD6mjPy41CvGiEGbicAm7h+MZq50aTyAnESlHQATmNxLHUlLpXy4jZ+M2iePAKlaoCWUY7GnMCi/dP37Wk7w==
+"@guardian/source-react-components-development-kitchen@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-7.1.1.tgz#e74c332be885fa82216eb1c1b33ef0e0084d0f07"
+  integrity sha512-TuS4iNCT3K2yT/ZB1Sa0wydHP0g7gQkBwfxZy/O01UYF5ipJBloqIOu/T5+jYz6CBwyfwqTjWQP/ynH5OXnOAw==
 
 "@guardian/source-react-components@^9.0.0":
   version "9.0.0"


### PR DESCRIPTION
## What does this change?

We rely on both `@guardian/source-react-components-development-kitchen` and `@guardian/libs` as peer dependencies, provided by the web platforms.

This PR loosens the peer dependencies for both and updates the dev dependency to the latest version.