### PR TITLE
Fix canRender file to include new Newsletter Epic templates

### DIFF
--- a/src/canRender.ts
+++ b/src/canRender.ts
@@ -1,12 +1,31 @@
+// Banners
+// --------------------------------------------
 import {
     COMPONENT_NAME as APP_BANNER_NAME,
     canRender as appBannerCanRender,
 } from './AppBanner/canRender';
+
 import {
     COMPONENT_NAME as DIGITAL_SUBSCRIBER_APP_BANNER_NAME,
     canRender as digitialSubCanRender,
 } from './DigitalSubscriberAppBanner/canRender';
+
+import {
+    COMPONENT_NAME as BANNER_WITH_LINK_NAME,
+    canRender as bannerWithLinkCanRender,
+} from './BannerWithLink/canRender';
+
+// Default Epics
+// --------------------------------------------
 import { COMPONENT_NAME as EPIC_NAME, canRender as epicCanRender } from './Epic/canRender';
+
+import {
+    COMPONENT_NAME as EPIC_WITH_IMAGE_NAME,
+    canRender as epicWithImageCanRender,
+} from './EpicWithSpecialHeader/canRender';
+
+// Old newsletter Epics
+// --------------------------------------------
 import {
     COMPONENT_NAME as NEWSLETTER_EPIC_NAME,
     canRender as newsletterEpicCanRender,
@@ -28,23 +47,27 @@ import {
 } from './UKNewsletterEpic/canRender';
 
 import {
-    COMPONENT_NAME as EPIC_WITH_IMAGE_NAME,
-    canRender as epicWithImageCanRender,
-} from './EpicWithSpecialHeader/canRender';
-
-import {
     COMPONENT_NAME as DTE_NEWSLETTER_EPIC_NAME,
     canRender as dteNewsletterEpicCanRender,
 } from './DownToEarthNewsletterEpic/canRender';
 
+// New newsletter Epics
+// --------------------------------------------
 import {
-    COMPONENT_NAME as BANNER_WITH_LINK_NAME,
-    canRender as bannerWithLinkCanRender,
-} from './BannerWithLink/canRender';
+    COMPONENT_NAME as EPICNEWSLETTER_AU_AFTERNOONUPDATE,
+    canRender as EpicNewsletter_AU_AfternoonUpdate_canRender,
+} from './EpicNewsletter_AU_AfternoonUpdate/canRender';
 
-/** These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
- * this means the user won't download the Braze components bundle when the component can't be shown.
- */
+import {
+    COMPONENT_NAME as EPICNEWSLETTER_THEGUIDE,
+    canRender as EpicNewsletter_TheGuide_canRender,
+} from './EpicNewsletter_TheGuide/canRender';
+
+
+// Types, functionality, exports
+// --------------------------------------------
+// These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered
+// + This means the user won't download the Braze components bundle when the component can't be shown.
 
 export type Extras = Record<string, string>;
 
@@ -54,14 +77,19 @@ const COMPONENT_CAN_RENDER_MAPPINGS: Record<
 > = {
     [APP_BANNER_NAME]: appBannerCanRender,
     [DIGITAL_SUBSCRIBER_APP_BANNER_NAME]: digitialSubCanRender,
+    [BANNER_WITH_LINK_NAME]: bannerWithLinkCanRender,
+
     [EPIC_NAME]: epicCanRender,
+    [EPIC_WITH_IMAGE_NAME]: epicWithImageCanRender,
+
     [NEWSLETTER_EPIC_NAME]: newsletterEpicCanRender,
     [US_NEWSLETTER_EPIC_NAME]: usNewsletterEpicCanRender,
     [AU_NEWSLETTER_EPIC_NAME]: auNewsletterEpicCanRender,
     [UK_NEWSLETTER_EPIC_NAME]: ukNewsletterEpicCanRender,
-    [EPIC_WITH_IMAGE_NAME]: epicWithImageCanRender,
     [DTE_NEWSLETTER_EPIC_NAME]: dteNewsletterEpicCanRender,
-    [BANNER_WITH_LINK_NAME]: bannerWithLinkCanRender,
+
+    [EPICNEWSLETTER_AU_AFTERNOONUPDATE]: EpicNewsletter_AU_AfternoonUpdate_canRender,
+    [EPICNEWSLETTER_THEGUIDE]: EpicNewsletter_TheGuide_canRender,
 };
 
 export const canRenderBrazeMsg = (msgExtras: Extras | undefined): boolean => {

--- a/src/canRender.ts
+++ b/src/canRender.ts
@@ -63,7 +63,6 @@ import {
     canRender as EpicNewsletter_TheGuide_canRender,
 } from './EpicNewsletter_TheGuide/canRender';
 
-
 // Types, functionality, exports
 // --------------------------------------------
 // These are in a seperate file to enable tree shaking of the logic deciding if a Braze message can be rendered


### PR DESCRIPTION
## What does this change?
A small update to make sure the new Newsletter Epic templates created in #385 will be rendered to End Users when required.
