### PR TITLE
Link CODE storybook to CODE preview for previewing rendering

### DIFF
--- a/.storybook/gu-preview/GuPreview.tsx
+++ b/.storybook/gu-preview/GuPreview.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, ReactElement } from 'react';
 import { styled } from '@storybook/theming';
 import { Icons, IconButton } from '@storybook/components';
 import { knobsData } from '../../src/utils/knobsData';
+import { getPreviewUrl } from '../utils';
 
 const IconButtonWithLabel = styled(IconButton)(() => ({
     display: 'inline-flex',
@@ -14,12 +15,11 @@ const IconButtonLabel = styled.div<{}>(({ theme }) => ({
 }));
 
 function constructPreviewUrl() {
-    let baseUrl =
-        'https://preview.gutools.co.uk/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey#';
+    let baseUrl = getPreviewUrl();
 
     const theKnobs = knobsData.get();
 
-    let fullUrl = baseUrl + 'force-braze-message=' + encodeURIComponent(JSON.stringify(theKnobs));
+    let fullUrl = baseUrl + '#force-braze-message=' + encodeURIComponent(JSON.stringify(theKnobs));
     window.open(fullUrl);
 }
 

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -45,4 +45,15 @@ const getLoginUrl = () => {
     }
 };
 
-export { getGridUrl, getImageSigningUrl, getLoginUrl };
+const getPreviewUrl = () => {
+    switch (getEnvironment()) {
+        case 'LOCAL':
+            return 'https://preview.code.dev-gutools.co.uk/education/shortcuts/2015/may/27/ban-rubbing-out-professor-says-erasers-instrument-of-the-devil-guy-claxton';
+        case 'CODE':
+            return 'https://preview.code.dev-gutools.co.uk/education/shortcuts/2015/may/27/ban-rubbing-out-professor-says-erasers-instrument-of-the-devil-guy-claxton';
+        case 'PROD':
+            return 'https://preview.gutools.co.uk/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey';
+    }
+}
+
+export { getGridUrl, getImageSigningUrl, getLoginUrl, getPreviewUrl };


### PR DESCRIPTION
## What does this change?

In storybook there's a button in the header to preview the components in place on the preview site. The CODE instance of storybook links to prod preview but it feels more useful to link to code preview.

## How to test

Click the button in CODE storybook and the component will render in CODE preview.