### PR TITLE
Update authored epic component to make it more configurable

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -6,6 +6,7 @@ import { COMPONENT_NAME, canRender, parseParagraphs } from './canRender';
 export { COMPONENT_NAME };
 import { replaceNonArticleCountPlaceholders } from './placeholders';
 import { TrackClick } from '../utils/tracking';
+import { HeaderSection } from '../EpicWithSpecialHeader';
 
 // Custom styles for <a> tags in the Epic content
 const linkStyles = css`
@@ -72,13 +73,18 @@ export type BrazeMessageProps = {
     remindMeConfirmationHeaderText?: string;
     remindMeConfirmationText?: string;
     hidePaymentIcons?: string;
+    authoredEpicHeader?: string;
+    authoredEpicImageUrl?: string;
+    authoredEpicImageAltText?: string;
+    authoredEpicBylineName?: string;
+    authoredEpicBylineCopy1?: string;
+    authoredEpicBylineCopy2?: string;
 };
 
 export type EpicProps = {
     ophanComponentId?: string;
     brazeMessageProps: BrazeMessageProps;
     countryCode?: string;
-    headerSection?: React.ReactNode;
     trackClick: TrackClick;
 };
 
@@ -94,9 +100,14 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
             remindMeConfirmationText,
             ophanComponentId,
             hidePaymentIcons,
+            authoredEpicHeader,
+            authoredEpicImageUrl,
+            authoredEpicImageAltText,
+            authoredEpicBylineName,
+            authoredEpicBylineCopy1,
+            authoredEpicBylineCopy2,
         },
         countryCode,
-        headerSection,
         trackClick,
     } = props;
 
@@ -114,7 +125,16 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
         <ThemeProvider theme={brand}>
             <div css={styles.epicWrapper}>
                 <section css={styles.epicContainer}>
-                    {headerSection}
+                    {authoredEpicImageUrl && (
+                        <HeaderSection
+                            authoredEpicImageUrl={authoredEpicImageUrl}
+                            authoredEpicImageAltText={authoredEpicImageAltText}
+                            authoredEpicHeader={authoredEpicHeader}
+                            authoredEpicBylineName={authoredEpicBylineName}
+                            authoredEpicBylineCopy1={authoredEpicBylineCopy1}
+                            authoredEpicBylineCopy2={authoredEpicBylineCopy2}
+                        />
+                    )}
 
                     <span css={styles.heading}>{heading}</span>
                     {paragraphs.map((text, index) => (

--- a/src/EpicWithSpecialHeader/index.stories.tsx
+++ b/src/EpicWithSpecialHeader/index.stories.tsx
@@ -8,6 +8,7 @@ import {
     buildEpicParagraphDocs,
 } from '../storybookCommon/argTypes';
 import { BrazeMessageProps } from '../Epic';
+import { grid, withGrid } from '../../.storybook/grid/withGrid';
 
 const NUMBER_OF_PARAGRAPHS = 9;
 const paragraphDocs = buildEpicParagraphDocs(NUMBER_OF_PARAGRAPHS);
@@ -15,13 +16,50 @@ const paragraphDocs = buildEpicParagraphDocs(NUMBER_OF_PARAGRAPHS);
 export default {
     component: 'EpicWithSpecialHeader',
     title: 'EndOfArticle/EpicWithSpecialHeader',
+    decorators: [withGrid],
+    parameters: {
+        grid: {
+            disable: false,
+        },
+    },
     argTypes: {
         ...coreArgTypes,
         ...ophanComponentIdArgType,
+        authoredEpicImageUrl: {
+            name: 'authoredEpicImageUrl',
+            type: { name: 'string' },
+            description:
+                'i.guim.co.uk URL for the byline image. Use the Grid image picker to select this.',
+        },
+        authoredEpicImageAltText: {
+            name: 'authoredEpicImageAltText',
+            type: { name: 'string' },
+            description: 'Accessible image alt text (never forget this!)',
+        },
+        authoredEpicHeader: {
+            name: 'authoredEpicHeader',
+            type: { name: 'string' },
+            description: 'Large header next to the byline image. Leave empty to suppress it.',
+        },
+        authoredEpicBylineName: {
+            name: 'authoredEpicBylineName',
+            type: { name: 'string' },
+            description: 'Byline name',
+        },
+        authoredEpicBylineCopy1: {
+            name: 'authoredEpicBylineCopy1',
+            type: { name: 'string' },
+            description: 'Byline copy line 1',
+        },
+        authoredEpicBylineCopy2: {
+            name: 'authoredEpicBylineCopy2',
+            type: { name: 'string' },
+            description: 'Byline copy line 2 (not always necessary)',
+        },
         heading: {
             name: 'heading',
             type: { name: 'string', required: true },
-            description: 'Header text',
+            description: 'Copy header text',
         },
         ...Object.fromEntries(paragraphDocs),
         highlightedText: {
@@ -51,6 +89,10 @@ export default {
 const StoryTemplate = (
     args: BrazeMessageProps & { componentName: string },
 ): ReactElement | null => {
+    const authoredEpicImageUrl = grid(
+        'https://i.guim.co.uk/img/media/cecfef4098a2a8c1e302e3f67b979f11ee529bb6/0_0_470_471/master/470.png?width=300&quality=45&s=d654e72595c07e2095777863f4901863',
+    );
+
     const brazeMessageProps = {
         ophanComponentId: args.ophanComponentId,
         heading: args.heading,
@@ -67,6 +109,12 @@ const StoryTemplate = (
         paragraph7: args.paragraph7,
         paragraph8: args.paragraph8,
         paragraph9: args.paragraph9,
+        authoredEpicImageUrl,
+        authoredEpicImageAltText: args.authoredEpicImageAltText,
+        authoredEpicHeader: args.authoredEpicHeader,
+        authoredEpicBylineName: args.authoredEpicBylineName,
+        authoredEpicBylineCopy1: args.authoredEpicBylineCopy1,
+        authoredEpicBylineCopy2: args.authoredEpicBylineCopy2,
     };
 
     knobsData.set({ ...brazeMessageProps, componentName: args.componentName });
@@ -91,6 +139,11 @@ const StoryTemplate = (
 export const DefaultStory = StoryTemplate.bind({});
 
 DefaultStory.args = {
+    authoredEpicImageAltText: 'Headshot image of Mark Rice-Oxley',
+    authoredEpicHeader: "You're powering open, independent journalism",
+    authoredEpicBylineName: 'Mark Rice-Oxley',
+    authoredEpicBylineCopy1: 'Executive Editor',
+    authoredEpicBylineCopy2: 'Reader Revenues',
     paragraph1:
         '... we have a small favour to ask. More people, <a href="https://example.com">like you</a>, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
     paragraph2:

--- a/src/EpicWithSpecialHeader/index.tsx
+++ b/src/EpicWithSpecialHeader/index.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { from, breakpoints, space, body, headline } from '@guardian/source-foundations';
-
 import { Epic } from '../Epic';
 import type { EpicProps } from '../Epic';
 
 export { COMPONENT_NAME } from './canRender';
 
-const HEADER_IMAGE_URL =
-    'https://i.guim.co.uk/img/media/cecfef4098a2a8c1e302e3f67b979f11ee529bb6/0_0_470_471/master/470.png?width=300&quality=45&s=d654e72595c07e2095777863f4901863';
+// const HEADER_IMAGE_URL =
+//     'https://i.guim.co.uk/img/media/cecfef4098a2a8c1e302e3f67b979f11ee529bb6/0_0_470_471/master/470.png?width=300&quality=45&s=d654e72595c07e2095777863f4901863';
 
 const emptyImage = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
@@ -52,34 +51,62 @@ const headerStyles = {
     `,
 };
 
+type HeaderSectionProps = {
+    authoredEpicImageUrl?: string;
+    authoredEpicImageAltText?: string;
+    authoredEpicHeader?: string;
+    authoredEpicBylineName?: string;
+    authoredEpicBylineCopy1?: string;
+    authoredEpicBylineCopy2?: string;
+};
+
 // We use a picture element here with an empty image for < tablet so that we
 // don't load an image unnecessarily when we're not going to render it (which would be
 // the case with an img tag)
-const HeaderSection: React.FC = () => (
-    <div css={headerStyles.container}>
-        <div css={headerStyles.leftContainer}>
-            <span css={headerStyles.text}>You&#8217;re powering open, independent journalism</span>
-        </div>
-        <div css={headerStyles.rightContainer}>
-            <picture css={headerStyles.picture}>
-                <source srcSet={emptyImage} media={`(max-width: ${breakpoints.tablet - 1}px)`} />
-                <source srcSet={HEADER_IMAGE_URL} media={`(min-width: ${breakpoints.tablet}px)`} />
-                <img css={headerStyles.image} src={HEADER_IMAGE_URL} alt="" />
-            </picture>
+export const HeaderSection: React.FC<HeaderSectionProps> = (props: HeaderSectionProps) => {
+    const {
+        authoredEpicImageUrl,
+        authoredEpicImageAltText,
+        authoredEpicHeader,
+        authoredEpicBylineName,
+        authoredEpicBylineCopy1,
+        authoredEpicBylineCopy2,
+    } = props;
 
-            <div css={headerStyles.imageCaptionContainer}>
-                <p css={[headerStyles.imageCaption, headerStyles.imageCaptionBold]}>
-                    Mark Rice-Oxley
-                </p>
-                <p css={[headerStyles.imageCaption, headerStyles.imageCaptionItalic]}>
-                    Executive Editor,
-                </p>
-                <p css={headerStyles.imageCaption}>Reader Revenues</p>
+    return (
+        <div css={headerStyles.container}>
+            <div css={headerStyles.leftContainer}>
+                <span css={headerStyles.text}>{authoredEpicHeader}</span>
+            </div>
+            <div css={headerStyles.rightContainer}>
+                <picture css={headerStyles.picture}>
+                    <source
+                        srcSet={emptyImage}
+                        media={`(max-width: ${breakpoints.tablet - 1}px)`}
+                    />
+                    <source
+                        srcSet={authoredEpicImageUrl}
+                        media={`(min-width: ${breakpoints.tablet}px)`}
+                    />
+                    <img
+                        css={headerStyles.image}
+                        src={authoredEpicImageUrl}
+                        alt={authoredEpicImageAltText}
+                    />
+                </picture>
+
+                <div css={headerStyles.imageCaptionContainer}>
+                    <p css={[headerStyles.imageCaption, headerStyles.imageCaptionBold]}>
+                        {authoredEpicBylineName}
+                    </p>
+                    <p css={[headerStyles.imageCaption, headerStyles.imageCaptionItalic]}>
+                        {authoredEpicBylineCopy1}
+                    </p>
+                    <p css={headerStyles.imageCaption}>{authoredEpicBylineCopy2}</p>
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
-export const EpicWithSpecialHeader: React.FC<EpicProps> = (props: EpicProps) => (
-    <Epic {...props} headerSection={<HeaderSection />} />
-);
+export const EpicWithSpecialHeader: React.FC<EpicProps> = (props: EpicProps) => <Epic {...props} />;


### PR DESCRIPTION
## What does this change?
Marketing have requested that we update the `EpicWithSpecialHeader` component to allow them to self-serve the editing of the component's image and byline copy and the accompanying header copy.

## Images

**Storybook: before change**
![Screenshot 2023-04-13 at 13 04 31](https://user-images.githubusercontent.com/5357530/231753598-3007d92e-15a9-447e-8039-7c5a06f02bf0.png)

**Storybook: after change**
![Screenshot 2023-04-13 at 13 04 48](https://user-images.githubusercontent.com/5357530/231753651-225adb24-2363-44a1-8ff4-37ed91a56ec8.png)

## Accessibility
This PR makes the `<img alt="" />` attribute configurable - previously it was served as a zero-length string