### PR TITLE
Legitimate image url check for epics

### DIFF
--- a/src/EpicWithSpecialHeader/canRender.ts
+++ b/src/EpicWithSpecialHeader/canRender.ts
@@ -1,4 +1,5 @@
 import { BrazeMessageProps } from '../Epic/index';
+import { isImageUrlAllowed } from '../utils/images';
 import { canRender as epicCanRender } from '../Epic/canRender';
 
 export const COMPONENT_NAME = 'EpicWithSpecialHeader';
@@ -8,7 +9,10 @@ export const canRender = (brazeMessageProps: BrazeMessageProps): boolean => {
     if (canRenderResult) {
         const { authoredEpicImageUrl, authoredEpicImageAltText, authoredEpicBylineName } =
             brazeMessageProps;
-
+        if (authoredEpicImageUrl && !isImageUrlAllowed(authoredEpicImageUrl)) {
+            console.log(`Image URL ${authoredEpicImageUrl} is not allowed`);
+            return false;
+        }
         return Boolean(authoredEpicImageUrl && authoredEpicImageAltText && authoredEpicBylineName);
     }
     return canRenderResult;


### PR DESCRIPTION
## What does this change?
When we updated the epicWithSpecialImage header we accidentally left out the check which determines whether the supplied image url comes from a permitted Guardian source. This PR rectifies the situation

## How to test
Test in Storybook
