### PR TITLE
Add card payment symbols option to styleable banner CTA button

### DIFF
--- a/src/Epic/ContributionsEpicButtons.tsx
+++ b/src/Epic/ContributionsEpicButtons.tsx
@@ -96,7 +96,7 @@ const RemindMeButton = ({ remindMeButtonText, onClick }: RemindMeButtonProps) =>
     </div>
 );
 
-const PaymentIcons = () => (
+export const PaymentIcons = () => (
     <img
         width={422}
         height={60}

--- a/src/StyleableBannerWithLink/index.stories.tsx
+++ b/src/StyleableBannerWithLink/index.stories.tsx
@@ -67,6 +67,11 @@ export default {
             name: 'buttonUrl',
             type: { name: 'string', required: true },
         },
+        showPaymentIcons: {
+            name: 'showPaymentIcons',
+            type: { name: 'string', required: false },
+            description: 'set to "true" to show payment icons near the button',
+        },
         styleButton: {
             name: 'styleButton',
             type: { name: 'string', required: false },
@@ -133,6 +138,7 @@ const StoryTemplate = (args: BrazeMessageProps & { componentName: string }): Rea
         styleHighlightBackground: args.styleHighlightBackground,
         buttonText: args.buttonText,
         buttonUrl: args.buttonUrl,
+        showPaymentIcons: args.showPaymentIcons,
         styleButton: args.styleButton,
         styleButtonBackground: args.styleButtonBackground,
         styleButtonHover: args.styleButtonHover,
@@ -179,6 +185,7 @@ DefaultStory.args = {
     buttonText: 'Take a look back',
     buttonUrl:
         'https://www.theguardian.com/info/ng-interactive/2020/dec/21/the-guardian-in-2020?INTCMP=gdnwb_mrtn_banner_edtrl_MK_SU_WorkingReport2020Canvas',
+    showPaymentIcons: 'false',
     styleButton: '#ffffff',
     styleButtonBackground: '#052962',
     styleButtonHover: '#234b8a',

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -4,6 +4,7 @@ import { useEscapeShortcut, OnCloseClick, CLOSE_BUTTON_ID } from '../bannerCommo
 import type { TrackClick } from '../utils/tracking';
 import { StyleData, selfServeStyles } from '../styles/bannerCommon';
 import { canRender, COMPONENT_NAME } from './canRender';
+import { PaymentIcons } from '../Epic/ContributionsEpicButtons';
 export { COMPONENT_NAME };
 
 export type BrazeMessageProps = {
@@ -18,6 +19,7 @@ export type BrazeMessageProps = {
     styleHighlightBackground?: string;
     buttonText?: string;
     buttonUrl?: string;
+    showPaymentIcons?: string;
     styleButton?: string;
     styleButtonBackground?: string;
     styleButtonHover?: string;
@@ -61,6 +63,7 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
             highlight,
             buttonText,
             buttonUrl,
+            showPaymentIcons = 'false',
             imageUrl,
             imageAltText = '',
             imagePosition = 'center',
@@ -107,18 +110,21 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
                             </>
                         ) : null}
                     </p>
-                    <LinkButton
-                        href={buttonUrl}
-                        css={styles.primaryButton}
-                        onClick={() =>
-                            trackClick({
-                                internalButtonId: 0,
-                                ophanComponentId: ophanComponentId as string,
-                            })
-                        }
-                    >
-                        {buttonText}
-                    </LinkButton>
+                    <div css={styles.primaryButtonWrapper}>
+                        <LinkButton
+                            href={buttonUrl}
+                            css={styles.primaryButton}
+                            onClick={() =>
+                                trackClick({
+                                    internalButtonId: 0,
+                                    ophanComponentId: ophanComponentId as string,
+                                })
+                            }
+                        >
+                            {buttonText}
+                        </LinkButton>
+                        {showPaymentIcons === 'true' && <PaymentIcons />}
+                    </div>
                 </div>
                 <div
                     css={

--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -204,6 +204,17 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
             margin-right: ${space[3]}px;
         `,
 
+        primaryButtonWrapper: css`
+            margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+
+            &.hidden {
+                display: none;
+            }
+        `,
+
         primaryButton: css`
             margin-right: ${space[3]}px;
             color: ${style.styleButton};


### PR DESCRIPTION
## What does this change?
A small update to the new styleable banner which will allow Marketing colleagues to add the payment icons to the main CTA button

## Screenshots
![Screenshot 2023-07-21 at 16 37 07](https://github.com/guardian/braze-components/assets/5357530/80e9ffb2-850f-434a-b6b0-5150e05f4710)

![Screenshot 2023-07-21 at 16 37 26](https://github.com/guardian/braze-components/assets/5357530/bbf0dbfb-c22e-48b5-bbf5-e0c6b5991938)

