### PR TITLE
Refactor components in preparation for reminders work

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -1,7 +1,7 @@
 import { css, ThemeProvider } from '@emotion/react';
 import React from 'react';
 import { brand, news, brandAlt, space, body, headline } from '@guardian/source-foundations';
-import { ContributionsEpicButtons } from './ContributionsEpicButtons';
+import { ContributionButtonWithReminder } from '../components/ContributionButtonWithReminder';
 import { COMPONENT_NAME, canRender, parseParagraphs } from './canRender';
 export { COMPONENT_NAME };
 import { replaceNonArticleCountPlaceholders } from './placeholders';
@@ -151,7 +151,7 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                         </p>
                     ))}
                     {/* buttonText and buttonUrl will have been checked for not undefined in canRenderEpic */}
-                    <ContributionsEpicButtons
+                    <ContributionButtonWithReminder
                         buttonText={buttonText as string}
                         buttonUrl={buttonUrl as string}
                         hidePaymentIcons={hidePaymentIcons}
@@ -164,7 +164,7 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                                 ophanComponentId: ophanComponentId as string,
                             })
                         }
-                    ></ContributionsEpicButtons>
+                    ></ContributionButtonWithReminder>
                 </section>
             </div>
         </ThemeProvider>

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -4,7 +4,7 @@ import { useEscapeShortcut, OnCloseClick, CLOSE_BUTTON_ID } from '../bannerCommo
 import type { TrackClick } from '../utils/tracking';
 import { StyleData, selfServeStyles } from '../styles/bannerCommon';
 import { canRender, COMPONENT_NAME } from './canRender';
-import { PaymentIcons } from '../Epic/ContributionsEpicButtons';
+import { PaymentIcons } from '../components/PaymentIcons';
 export { COMPONENT_NAME };
 
 export type BrazeMessageProps = {

--- a/src/components/ContributionButtonWithReminder.tsx
+++ b/src/components/ContributionButtonWithReminder.tsx
@@ -3,7 +3,8 @@ import { css, ThemeProvider } from '@emotion/react';
 import { neutral, brandAlt, space } from '@guardian/source-foundations';
 import { Button, LinkButton, SvgArrowRightStraight } from '@guardian/source-react-components';
 
-import { RemindMeConfirmation } from './RemindMeConfirmation';
+import { ReminderCtaConfirmation } from './ReminderCtaConfirmation';
+import { PaymentIcons } from './PaymentIcons';
 
 const PRIMARY_BUTTON_INTERNAL_ID = 0;
 const REMIND_ME_BUTTON_INTERNAL_ID = 1;
@@ -17,13 +18,6 @@ const buttonWrapperStyles = css`
     &.hidden {
         display: none;
     }
-`;
-
-const paymentImageStyles = css`
-    display: inline-block;
-    width: auto;
-    height: 25px;
-    margin: ${space[1]}px 0;
 `;
 
 const buttonMargins = css`
@@ -96,17 +90,7 @@ const RemindMeButton = ({ remindMeButtonText, onClick }: RemindMeButtonProps) =>
     </div>
 );
 
-export const PaymentIcons = () => (
-    <img
-        width={422}
-        height={60}
-        src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
-        alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
-        css={paymentImageStyles}
-    />
-);
-
-interface ContributionsEpicButtonsProps {
+interface ContributionButtonWithReminderProps {
     buttonText: string;
     buttonUrl: string;
     remindMeButtonText?: string;
@@ -117,7 +101,7 @@ interface ContributionsEpicButtonsProps {
 }
 type SectionState = 'DEFAULT' | 'REMINDER_CONFIRMED' | 'REMINDER_CONFIRMATION_CLOSED';
 
-export const ContributionsEpicButtons = ({
+export const ContributionButtonWithReminder = ({
     buttonText,
     buttonUrl,
     remindMeButtonText,
@@ -125,13 +109,13 @@ export const ContributionsEpicButtons = ({
     remindMeConfirmationHeaderText,
     trackClick,
     hidePaymentIcons,
-}: ContributionsEpicButtonsProps): JSX.Element => {
+}: ContributionButtonWithReminderProps): JSX.Element => {
     const [sectionState, setSectionState] = useState<SectionState>('DEFAULT');
     const showPaymentIcons = hidePaymentIcons !== 'true';
 
     if (sectionState === 'REMINDER_CONFIRMED') {
         return (
-            <RemindMeConfirmation
+            <ReminderCtaConfirmation
                 remindMeConfirmationText={remindMeConfirmationText as string}
                 remindMeConfirmationHeaderText={remindMeConfirmationHeaderText as string}
                 onClose={() => setSectionState('REMINDER_CONFIRMATION_CLOSED')}

--- a/src/components/PaymentIcons.tsx
+++ b/src/components/PaymentIcons.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { space } from '@guardian/source-foundations';
+
+const paymentImageStyles = css`
+    display: inline-block;
+    width: auto;
+    height: 25px;
+    margin: ${space[1]}px 0;
+`;
+
+export const PaymentIcons = () => (
+    <img
+        width={422}
+        height={60}
+        src="https://assets.guim.co.uk/images/acquisitions/2db3a266287f452355b68d4240df8087/payment-methods.png"
+        alt="Accepted payment methods: Visa, Mastercard, American Express and PayPal"
+        css={paymentImageStyles}
+    />
+);

--- a/src/components/ReminderCtaConfirmation.tsx
+++ b/src/components/ReminderCtaConfirmation.tsx
@@ -40,17 +40,17 @@ const successHeadingStyles = css`
     margin: ${space[2]}px 0;
 `;
 
-type Props = {
+type ReminderCtaConfirmationProps = {
     remindMeConfirmationHeaderText: string;
     remindMeConfirmationText: string;
     onClose: () => void;
 };
 
-export const RemindMeConfirmation = ({
+export const ReminderCtaConfirmation = ({
     remindMeConfirmationText,
     remindMeConfirmationHeaderText,
     onClose,
-}: Props): JSX.Element => {
+}: ReminderCtaConfirmationProps): JSX.Element => {
     return (
         <div css={reminderConfirmationContainerStyles}>
             <div css={closeButtonContainerStyles}>


### PR DESCRIPTION
## What does this change?
This small PR reorganises some components that are about to be shared between Braze Epics and Banners (principally the contributions-with-reminders buttons) into a new `components` folder

## Testing
Storybook should be sufficient

## Release
I suggest we don't publish the repo after this PR is merged into main?