### PR TITLE
Styleable banner hotfixes

### DIFF
--- a/src/AppBanner/index.tsx
+++ b/src/AppBanner/index.tsx
@@ -105,7 +105,7 @@ export const AppBanner = (props: Props): ReactElement | null => {
                     <p css={commonStyles.paragraph}>
                         {body}
                         <br />
-                        <strong css={commonStyles.highlight}>{cta}</strong>
+                        <strong css={commonStyles.highlight}>{cta} &nbsp;</strong>
                         <span css={styles.storeIcon}>
                             <AppStore />
                             <PlayStore />

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -105,7 +105,7 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
 
                         {highlight ? (
                             <>
-                                <br />
+                                <br />&nbsp;<br />
                                 <strong css={styles.highlight}>{highlight}</strong>
                             </>
                         ) : null}

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -100,18 +100,13 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
             <div css={styles.contentContainer}>
                 <div css={styles.topLeftComponent}>
                     <div css={styles.heading}>{header}</div>
-                    <p css={styles.paragraph}>
-                        {body}
+                    <p css={styles.paragraph}>{body}</p>
 
-                        {highlight ? (
-                            <>
-                                <br />
-                                &nbsp;
-                                <br />
-                                <strong css={styles.highlight}>{highlight}</strong>
-                            </>
-                        ) : null}
-                    </p>
+                    {highlight ? (
+                        <p css={styles.highlightContainer}>
+                            <strong css={styles.highlight}>{highlight}</strong>
+                        </p>
+                    ) : null}
                     <div css={styles.primaryButtonWrapper}>
                         <LinkButton
                             href={buttonUrl}

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -105,7 +105,9 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
 
                         {highlight ? (
                             <>
-                                <br />&nbsp;<br />
+                                <br />
+                                &nbsp;
+                                <br />
                                 <strong css={styles.highlight}>{highlight}</strong>
                             </>
                         ) : null}

--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -195,7 +195,7 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
             font-weight: 700;
             margin-top: ${space[5]}px;
             margin-right: ${space[3]}px;
-            display: inline-block;
+            display: inline;
             color: ${style.styleHighlight};
             background-color: ${style.styleHighlightBackground};
         `,
@@ -280,6 +280,7 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
         centeredBottomRightComponent: css`
             display: flex;
             justify-content: center;
+            align-items: center;
             width: 100%;
             max-height: 100%;
 

--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -191,11 +191,37 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
             }
         `,
 
-        highlight: css`
-            font-weight: 700;
+        highlightContainer: css`
+            ${body.medium()}
             margin-top: ${space[5]}px;
             margin-right: ${space[3]}px;
-            display: inline;
+            max-width: 100%;
+
+            ${from.phablet} {
+                max-width: 90%;
+            }
+
+            ${from.tablet} {
+                max-width: 100%;
+            }
+
+            ${from.desktop} {
+                font-size: 20px;
+                margin: ${space[3]}px 0 ${space[4]}px;
+                max-width: 42rem;
+            }
+
+            ${from.leftCol} {
+                max-width: 37rem;
+            }
+
+            ${from.wide} {
+                max-width: 42rem;
+            }
+        `,
+
+        highlight: css`
+            font-weight: 700;
             color: ${style.styleHighlight};
             background-color: ${style.styleHighlightBackground};
         `,


### PR DESCRIPTION
## What does this change?
Marketing reported 2 issues with the new styleable banner:
1 - the image does not center
2 - the highlighted text background color expands to fill the block rather than just highlight the text

We need to fix these issues so they can release a banner as part of the new Europe edition launch

## Screenshots

**Before fix**
![Screenshot 2023-09-18 at 15 57 06](https://github.com/guardian/braze-components/assets/5357530/a8069db6-62da-4c84-91dd-8696d6f42304)

**After fix**
![Screenshot 2023-09-18 at 15 57 38](https://github.com/guardian/braze-components/assets/5357530/818d6d82-ece6-4e47-a377-b862dd82396b)
