### PR TITLE
Fix spacing on BannerWithLink and AppBanner

### DIFF
--- a/src/AppBanner/index.tsx
+++ b/src/AppBanner/index.tsx
@@ -104,7 +104,7 @@ export const AppBanner = (props: Props): ReactElement | null => {
                     <div css={commonStyles.heading}>{header}</div>
                     <p css={commonStyles.paragraph}>{body}</p>
 
-                    <p css={commonStyles.paragraph}>
+                    <p css={[commonStyles.paragraph, commonStyles.highlightContainer]}>
                         <strong css={commonStyles.highlight}>{cta} &nbsp;</strong>
                         <span css={styles.storeIcon}>
                             <AppStore />

--- a/src/AppBanner/index.tsx
+++ b/src/AppBanner/index.tsx
@@ -104,7 +104,7 @@ export const AppBanner = (props: Props): ReactElement | null => {
                     <div css={commonStyles.heading}>{header}</div>
                     <p css={commonStyles.paragraph}>{body}</p>
 
-                    <p css={[commonStyles.paragraph, commonStyles.highlightContainer]}>
+                    <p css={commonStyles.highlightContainer}>
                         <strong css={commonStyles.highlight}>{cta} &nbsp;</strong>
                         <span css={styles.storeIcon}>
                             <AppStore />

--- a/src/AppBanner/index.tsx
+++ b/src/AppBanner/index.tsx
@@ -102,15 +102,16 @@ export const AppBanner = (props: Props): ReactElement | null => {
             <div css={commonStyles.contentContainer}>
                 <div css={commonStyles.topLeftComponent}>
                     <div css={commonStyles.heading}>{header}</div>
+                    <p css={commonStyles.paragraph}>{body}</p>
+
                     <p css={commonStyles.paragraph}>
-                        {body}
-                        <br />
                         <strong css={commonStyles.highlight}>{cta} &nbsp;</strong>
                         <span css={styles.storeIcon}>
                             <AppStore />
                             <PlayStore />
                         </span>
                     </p>
+
                     <ThemeProvider theme={overrridenReaderRevenueTheme}>
                         <Button
                             onClick={(e) => onCloseClick(e, 0)}

--- a/src/BannerWithLink/index.tsx
+++ b/src/BannerWithLink/index.tsx
@@ -82,16 +82,14 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
             <div css={styles.contentContainer}>
                 <div css={styles.topLeftComponent}>
                     <div css={styles.heading}>{header}</div>
-                    <p css={styles.paragraph}>
-                        {body}
+                    <p css={styles.paragraph}>{body}</p>
 
-                        {boldText ? (
-                            <>
-                                <br />
-                                <strong css={styles.highlight}>{boldText}</strong>
-                            </>
-                        ) : null}
-                    </p>
+                    {boldText ? (
+                        <p css={styles.highlightContainer}>
+                            <strong css={styles.highlight}>{boldText}</strong>
+                        </p>
+                    ) : null}
+
                     <LinkButton
                         href={buttonUrl}
                         css={styles.primaryButton}


### PR DESCRIPTION
## What does this change?

This updates the markup in BannerWithLink and AppBanner to match StyleableBannerWithLink so that the shared styling is applied in the same way. Previously after #424 was merged we lost a bit of spacing between the body text and highlighted text on other banners as the container didn't exist in the markup.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Storybook!

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
