### PR TITLE
Fix images in Braze banners

### DIFF
--- a/src/AppBanner/index.tsx
+++ b/src/AppBanner/index.tsx
@@ -100,7 +100,7 @@ export const AppBanner = (props: Props): ReactElement | null => {
     return (
         <div css={commonStyles.wrapper}>
             <div css={commonStyles.contentContainer}>
-                <div css={commonStyles.topLeftComponent}>
+                <div css={commonStyles.leftPanel}>
                     <div css={commonStyles.heading}>{header}</div>
                     <p css={commonStyles.paragraph}>{body}</p>
 
@@ -137,27 +137,23 @@ export const AppBanner = (props: Props): ReactElement | null => {
                         </Button>
                     </ThemeProvider>
                 </div>
-                <div css={commonStyles.bottomRightComponent}>
-                    <div css={styles.image}>
-                        <img src={imageUrl} alt="" />
-                    </div>
-                    <div css={commonStyles.iconPanel}>
-                        <ThemeProvider theme={overrridenReaderRevenueTheme}>
-                            <Button
-                                icon={<SvgCross />}
-                                hideLabel={true}
-                                css={commonStyles.closeButton}
-                                priority="tertiary"
-                                size="small"
-                                aria-label="Close"
-                                onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
-                                tabIndex={0}
-                            >
-                                {' '}
-                            </Button>
-                        </ThemeProvider>
-                    </div>
+                <div css={[commonStyles.rightPanel, commonStyles.rightPanelBaseAligned]}>
+                    <img src={imageUrl} alt="" css={commonStyles.image} />
                 </div>
+                <ThemeProvider theme={overrridenReaderRevenueTheme}>
+                    <Button
+                        icon={<SvgCross />}
+                        hideLabel={true}
+                        css={commonStyles.closeButton}
+                        priority="tertiary"
+                        size="small"
+                        aria-label="Close"
+                        onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
+                        tabIndex={0}
+                    >
+                        {' '}
+                    </Button>
+                </ThemeProvider>
             </div>
         </div>
     );

--- a/src/AppBanner/styles.ts
+++ b/src/AppBanner/styles.ts
@@ -1,31 +1,7 @@
 import { css } from '@emotion/react';
-import { space, from, until } from '@guardian/source-foundations';
+import { space } from '@guardian/source-foundations';
 
 export const styles = {
-    image: css`
-        max-width: 100%;
-        max-height: 260px;
-        display: flex;
-        justify-content: center;
-        align-items: flex-end;
-        margin-top: -20px;
-
-        img {
-            max-width: 100%;
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
-        }
-
-        ${until.desktop} {
-            display: none;
-        }
-
-        ${from.wide} {
-            margin-right: 100px;
-        }
-    `,
-
     storeIcon: css`
         height: 10px;
         display: inline-block;

--- a/src/BannerNewsletter/index.stories.tsx
+++ b/src/BannerNewsletter/index.stories.tsx
@@ -55,6 +55,12 @@ export default {
             description:
                 'i.guim.co.uk URL for the banner image. Use the Grid image picker to select this.',
         },
+        imageIsSquare: {
+            name: 'imageIsSquare',
+            type: { name: 'string', required: false },
+            description:
+                'Image shape: "true" (default) if image is squarish; other values indicate image width is significantly larger than height',
+        },
     },
 };
 
@@ -76,6 +82,7 @@ const StoryTemplate = (
         boldText: args.boldText,
         secondParagraph: args.secondParagraph,
         imageUrl,
+        imageIsSquare: args.imageIsSquare,
         ophanComponentId: args.ophanComponentId,
     };
 
@@ -113,6 +120,7 @@ DefaultStory.args = {
     boldText: 'Sign up today!',
     secondParagraph:
         'We thought you should know this newsletter may contain information about Guardian products and services.',
+    imageIsSquare: 'true',
 };
 
 DefaultStory.story = { name: 'BannerNewsletter' };

--- a/src/BannerNewsletter/index.tsx
+++ b/src/BannerNewsletter/index.tsx
@@ -51,6 +51,7 @@ export type BrazeMessageProps = {
     boldText?: string;
     secondParagraph?: string;
     imageUrl?: string;
+    imageIsSquare?: string;
     newsletterId?: string;
     frequency?: string;
 };
@@ -75,6 +76,7 @@ const BannerNewsletter: React.FC<Props> = (props: Props) => {
             secondParagraph,
             newsletterId,
             imageUrl,
+            imageIsSquare,
             frequency,
         },
         subscribeToNewsletter,
@@ -108,7 +110,7 @@ const BannerNewsletter: React.FC<Props> = (props: Props) => {
     return (
         <div css={styles.wrapper}>
             <div css={styles.contentContainer}>
-                <div css={styles.topLeftComponent}>
+                <div css={styles.leftPanel}>
                     <div css={localStyles.heading}>{header}</div>
                     <NewsletterFrequency frequency={frequency} />
                     <p css={styles.paragraph}>
@@ -124,25 +126,29 @@ const BannerNewsletter: React.FC<Props> = (props: Props) => {
                         trackClick={trackClick}
                     />
                 </div>
-                <div css={styles.centeredBottomRightComponent}>
-                    <div css={styles.centeredImage}>
-                        <img src={imageUrl} alt="" />
-                    </div>
-                    <div css={styles.iconPanel}>
-                        <Button
-                            icon={<SvgCross />}
-                            hideLabel={true}
-                            cssOverrides={styles.closeButton}
-                            priority="tertiary"
-                            size="small"
-                            aria-label="Close"
-                            onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
-                            tabIndex={0}
-                        >
-                            {' '}
-                        </Button>
-                    </div>
+                <div css={styles.rightPanel}>
+                    <img
+                        src={imageUrl}
+                        alt=""
+                        css={
+                            imageIsSquare === 'true'
+                                ? [styles.image, styles.imageIsSquare]
+                                : styles.image
+                        }
+                    />
                 </div>
+                <Button
+                    icon={<SvgCross />}
+                    hideLabel={true}
+                    cssOverrides={styles.closeButton}
+                    priority="tertiary"
+                    size="small"
+                    aria-label="Close"
+                    onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
+                    tabIndex={0}
+                >
+                    {' '}
+                </Button>
             </div>
         </div>
     );

--- a/src/BannerWithLink/index.tsx
+++ b/src/BannerWithLink/index.tsx
@@ -80,7 +80,7 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
     return (
         <div css={styles.wrapper}>
             <div css={styles.contentContainer}>
-                <div css={styles.topLeftComponent}>
+                <div css={styles.leftPanel}>
                     <div css={styles.heading}>{header}</div>
                     <p css={styles.paragraph}>{body}</p>
 
@@ -103,25 +103,21 @@ const BannerWithLink: React.FC<Props> = (props: Props) => {
                         {buttonText}
                     </LinkButton>
                 </div>
-                <div css={styles.bottomRightComponent}>
-                    <div css={styles.image}>
-                        <img src={imageUrl} alt="" />
-                    </div>
-                    <div css={styles.iconPanel}>
-                        <Button
-                            icon={<SvgCross />}
-                            hideLabel={true}
-                            cssOverrides={styles.closeButton}
-                            priority="tertiary"
-                            size="small"
-                            aria-label="Close"
-                            onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
-                            tabIndex={0}
-                        >
-                            {' '}
-                        </Button>
-                    </div>
+                <div css={[styles.rightPanel, styles.rightPanelBaseAligned]}>
+                    <img src={imageUrl} alt="" css={styles.image} />
                 </div>
+                <Button
+                    icon={<SvgCross />}
+                    hideLabel={true}
+                    cssOverrides={styles.closeButton}
+                    priority="tertiary"
+                    size="small"
+                    aria-label="Close"
+                    onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
+                    tabIndex={0}
+                >
+                    {' '}
+                </Button>
             </div>
         </div>
     );

--- a/src/StyleableBannerWithLink/index.stories.tsx
+++ b/src/StyleableBannerWithLink/index.stories.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { BrazeBannerComponent } from '../BrazeBannerComponent';
-import { StorybookWrapper, mockFetchEmail } from '../utils/StorybookWrapper';
+import { StorybookWrapper, mockSubscribe, mockFetchEmail } from '../utils/StorybookWrapper';
 import { knobsData } from '../utils/knobsData';
 import { coreArgTypes, ophanComponentIdArgType } from '../storybookCommon/argTypes';
 import { BrazeMessageProps } from '.';
@@ -104,6 +104,12 @@ export default {
             type: { name: 'string', required: false },
             description: 'Image vertical position - options: "bottom", "center" (default)',
         },
+        imageIsSquare: {
+            name: 'imageIsSquare',
+            type: { name: 'string', required: false },
+            description:
+                'Image shape: "true" (default) if image is squarish; other values indicate image width is significantly larger than height',
+        },
         styleClose: {
             name: 'styleClose',
             type: { name: 'string', required: false },
@@ -123,8 +129,12 @@ export default {
 };
 
 const StoryTemplate = (args: BrazeMessageProps & { componentName: string }): ReactElement => {
+    // const imageUrl = grid(
+    //     'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+    // );
+
     const imageUrl = grid(
-        'https://i.guim.co.uk/img/media/35d403182e4b262d37385281b19b763ee6b32f6a/58_0_1743_1046/master/1743.png?width=930&quality=45&auto=format&s=9ecd82413fef9883c1e7a0df2bf6abb1',
+        'https://i.guim.co.uk/img/media/64fe3c6700df501ef6e629f2f2cde094cbfaa389/25_0_2979_2976/master/2979.png?width=930&quality=45&auto=format&s=cebf1ac7ee57e7ea21534147a11926a3',
     );
 
     const brazeMessageProps: BrazeMessageProps = {
@@ -145,6 +155,7 @@ const StoryTemplate = (args: BrazeMessageProps & { componentName: string }): Rea
         imageUrl,
         imageAltText: args.imageAltText,
         imagePosition: args.imagePosition,
+        imageIsSquare: args.imageIsSquare,
         styleClose: args.styleClose,
         styleCloseBackground: args.styleCloseBackground,
         styleCloseHover: args.styleCloseHover,
@@ -161,6 +172,7 @@ const StoryTemplate = (args: BrazeMessageProps & { componentName: string }): Rea
                 logButtonClickWithBraze={(internalButtonId) => {
                     console.log(`Button with internal ID ${internalButtonId} clicked`);
                 }}
+                subscribeToNewsletter={() => mockSubscribe('0')}
                 fetchEmail={() => mockFetchEmail()}
                 submitComponentEvent={(componentEvent) => {
                     console.log('submitComponentEvent called with: ', componentEvent);
@@ -192,6 +204,7 @@ DefaultStory.args = {
     styleButtonHover: '#234b8a',
     imageAltText: 'Accessible image description',
     imagePosition: 'bottom',
+    imageIsSquare: 'true',
     styleClose: '#052962',
     styleCloseBackground: '#ededed',
     styleCloseHover: '#e5e5e5',

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -26,6 +26,7 @@ export type BrazeMessageProps = {
     imageUrl?: string;
     imageAltText?: string;
     imagePosition?: string;
+    imageIsSquare?: string;
     styleClose?: string;
     styleCloseBackground?: string;
     styleCloseHover?: string;
@@ -67,6 +68,7 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
             imageUrl,
             imageAltText = '',
             imagePosition = 'center',
+            imageIsSquare = 'true',
         },
         trackClick,
     } = props;
@@ -98,7 +100,7 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
     return (
         <div css={styles.wrapper}>
             <div css={styles.contentContainer}>
-                <div css={styles.topLeftComponent}>
+                <div css={styles.leftPanel}>
                     <div css={styles.heading}>{header}</div>
                     <p css={styles.paragraph}>{body}</p>
 
@@ -126,28 +128,32 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
                 <div
                     css={
                         imagePosition === 'bottom'
-                            ? styles.bottomRightComponent
-                            : styles.centeredBottomRightComponent
+                            ? [styles.rightPanel, styles.rightPanelBaseAligned]
+                            : styles.rightPanel
                     }
                 >
-                    <div css={imagePosition === 'bottom' ? styles.image : styles.centeredImage}>
-                        <img src={imageUrl} alt={imageAltText} />
-                    </div>
-                    <div css={styles.iconPanel}>
-                        <Button
-                            icon={<SvgCross />}
-                            hideLabel={true}
-                            cssOverrides={styles.closeButton}
-                            priority="tertiary"
-                            size="small"
-                            aria-label="Close"
-                            onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
-                            tabIndex={0}
-                        >
-                            {' '}
-                        </Button>
-                    </div>
+                    <img
+                        src={imageUrl}
+                        alt={imageAltText}
+                        css={
+                            imageIsSquare === 'true'
+                                ? [styles.image, styles.imageIsSquare]
+                                : styles.image
+                        }
+                    />
                 </div>
+                <Button
+                    icon={<SvgCross />}
+                    hideLabel={true}
+                    cssOverrides={styles.closeButton}
+                    priority="tertiary"
+                    size="small"
+                    aria-label="Close"
+                    onClick={(e) => onCloseClick(e, CLOSE_BUTTON_ID)}
+                    tabIndex={0}
+                >
+                    {' '}
+                </Button>
             </div>
         </div>
     );

--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import type { Extras } from '../logic/types';
-import { neutral, space, from, until, body, headline } from '@guardian/source-foundations';
+import { space, from, body, headline } from '@guardian/source-foundations';
 
 const imgHeight = '280';
 
@@ -65,31 +65,14 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
     return {
         wrapper: css`
             box-sizing: border-box;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
             width: 100%;
             background-color: ${style.styleBackground};
-            color: ${neutral[20]};
-
-            html {
-                box-sizing: border-box;
-            }
-
-            *,
-            *:before,
-            *:after {
-                box-sizing: inherit;
-            }
+            display: flex;
+            justify-content: center;
         `,
-
         contentContainer: css`
-            align-items: stretch;
             display: flex;
             flex-direction: column;
-            position: relative;
-            margin: 0 auto;
             width: 100%;
             max-width: 740px;
 
@@ -107,140 +90,66 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
                 max-width: 1300px;
             }
         `,
-
-        topLeftComponent: css`
+        leftPanel: css`
             width: 93%;
             padding: ${space[4]}px;
             min-height: ${imgHeight}px;
+
             ${from.desktop} {
                 width: 60%;
             }
         `,
-
-        bottomRightComponent: css`
-            display: flex;
-            justify-content: center;
-            width: 100%;
-            max-height: 100%;
-
-            ${from.desktop} {
-                align-self: flex-end;
-                padding-right: ${space[4]}px;
-                max-width: 45%;
-                justify-content: flex-end;
-            }
-
-            ${from.leftCol} {
-                padding-right: 0;
-                justify-content: space-between;
-            }
-
-            ${from.wide} {
-                max-width: 48%;
-            }
-        `,
-
         heading: css`
             ${headline.small({ fontWeight: 'bold' })};
             margin: 0;
-            max-width: 100%;
+            max-width: 85%;
             color: ${style.styleHeader};
 
-            ${from.mobileLandscape} {
-                ${headline.small({ fontWeight: 'bold' })};
-            }
-
-            ${from.tablet} {
+            ${from.desktop} {
                 max-width: 100%;
             }
         `,
-
         paragraph: css`
             ${body.medium()}
             line-height: 135%;
-            margin: ${space[5]}px 0 ${space[5]}px;
+            margin-top: ${space[5]}px;
             max-width: 100%;
             color: ${style.styleBody};
 
-            ${from.phablet} {
-                max-width: 90%;
-            }
-
-            ${from.tablet} {
-                max-width: 100%;
-            }
-
             ${from.desktop} {
                 font-size: 20px;
-                margin: ${space[3]}px 0 ${space[4]}px;
-                max-width: 42rem;
-            }
-
-            ${from.leftCol} {
-                max-width: 37rem;
-            }
-
-            ${from.wide} {
-                max-width: 42rem;
+                margin-top: ${space[3]}px;
             }
         `,
-
         secondParagraph: css`
             ${from.desktop} {
                 font-size: 18px;
             }
         `,
-
         highlightContainer: css`
             ${body.medium()}
             margin-top: ${space[5]}px;
-            margin-right: ${space[3]}px;
             max-width: 100%;
-
-            ${from.phablet} {
-                max-width: 90%;
-            }
-
-            ${from.tablet} {
-                max-width: 100%;
-            }
 
             ${from.desktop} {
                 font-size: 20px;
-                margin: ${space[3]}px 0 ${space[4]}px;
-                max-width: 42rem;
-            }
-
-            ${from.leftCol} {
-                max-width: 37rem;
-            }
-
-            ${from.wide} {
-                max-width: 42rem;
+                margin-top: ${space[3]}px;
             }
         `,
-
         highlight: css`
             font-weight: 700;
             color: ${style.styleHighlight};
             background-color: ${style.styleHighlightBackground};
         `,
-
         smallRightSpacer: css`
             margin-right: ${space[3]}px;
         `,
-
         primaryButtonWrapper: css`
             margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
             display: flex;
             flex-wrap: wrap;
             align-items: center;
-
-            &.hidden {
-                display: none;
-            }
         `,
-
         primaryButton: css`
             margin-right: ${space[3]}px;
             color: ${style.styleButton};
@@ -249,101 +158,43 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
                 background-color: ${style.styleButtonHover};
             }
         `,
+        rightPanel: css`
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            margin-top: ${space[12]}px;
+            margin-right: ${space[4]}px;
+            width: 40%;
+            display: none;
 
-        iconPanel: css`
             ${from.desktop} {
                 display: flex;
-                flex-direction: column;
-                justify-content: space-between;
-                align-items: flex-end;
-                height: 100%;
-                padding: ${space[4]}px 0;
-                margin-left: ${space[4]}px;
             }
         `,
-
+        rightPanelBaseAligned: css`
+            justify-content: flex-end;
+        `,
+        image: css`
+            width: 100%;
+            object-fit: contain;
+        `,
+        imageIsSquare: css`
+            width: 50%;
+        `,
         closeButton: css`
-            display: flex;
-            align-items: center;
-            justify-content: center;
             padding: 0;
             position: absolute;
-            top: 15px;
-            right: 10px;
+            top: ${space[4]}px;
+            right: ${space[4]}px;
             border: 1px solid ${style.styleClose};
             background-color: ${style.styleCloseBackground};
+
             &:hover {
                 background-color: ${style.styleCloseHover};
             }
+
             & svg {
                 fill: ${style.styleClose};
-            }
-        `,
-
-        image: css`
-            max-width: 100%;
-            max-height: 300px;
-            display: flex;
-            justify-content: center;
-            align-items: flex-end;
-            margin-top: ${space[2]}px;
-
-            img {
-                max-width: 100%;
-                width: 100%;
-                height: 100%;
-                object-fit: contain;
-            }
-
-            ${until.desktop} {
-                display: none;
-            }
-
-            ${from.wide} {
-                margin-right: 100px;
-            }
-        `,
-        centeredBottomRightComponent: css`
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: 100%;
-            max-height: 100%;
-
-            ${from.desktop} {
-                padding-right: ${space[4]}px;
-                max-width: 45%;
-            }
-
-            ${from.leftCol} {
-                padding-right: 0;
-            }
-
-            ${from.wide} {
-                max-width: 48%;
-            }
-        `,
-        centeredImage: css`
-            max-width: 100%;
-            max-height: 300px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin-top: ${space[2]}px;
-
-            img {
-                max-width: 100%;
-                width: 100%;
-                height: 100%;
-                object-fit: contain;
-            }
-
-            ${until.desktop} {
-                display: none;
-            }
-
-            ${from.wide} {
-                margin-right: 100px;
             }
         `,
     };


### PR DESCRIPTION
## What does this change?
A rewrite to simplify and fix CSS code for Braze banners, alongside minor tweaks to the component code to accommodate the revised CSS

## How to test
Storybook in CODE

## Have we considered potential risks?
This fix assumes that all current newsletter banners are using "square" images (as opposed to "landscape ones). We need to check with marketing to confirm this is the case. If not, then they will need to update affected canvas campaigns in Braze

## Images
[TODO]