### PR TITLE
Fix for centered image in StyleableBanner

### DIFF
--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -306,7 +306,7 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
         centeredBottomRightComponent: css`
             display: flex;
             justify-content: center;
-            align-items: center;
+            align-self: center;
             width: 100%;
             max-height: 100%;
 
@@ -330,6 +330,7 @@ export const selfServeStyles = (userVals: Extras, defaults: StyleData) => {
             justify-content: center;
             align-items: center;
             margin-top: ${space[2]}px;
+            margin-bottom: ${space[2]}px;
 
             img {
                 max-width: 100%;


### PR DESCRIPTION
## What does this change?

We've found that when the image is centered it can outgrow the container it sits within. For some reason using `align-self` instead of `align-items` seems to have a positive effect.

This also affects the NewsletterBanner.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
