### PR TITLE
Update local DCR instructions to use `yalc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,37 +54,45 @@ This means you won't need to run the login service locally.
 
 ### Point a project to your local version of @guardian/braze-components
 
-Use [`yarn link`] to develop against a locally checked out version of this
-library:
+Sometimes it's useful to test a braze-components change against a locally
+running version of a project which uses it, for example DCR.
 
-In your local checkout of `@guardian/braze-components`:
+It is recommended to use [`yalc`](https://github.com/wclr/yalc) to do this.
 
-```
-$ yarn link
-```
+#### Install yalc
 
-And then in the project consuming the client (e.g. DCR/frontend):
+Follow the instructions in the [yalc README](https://github.com/wclr/yalc#installation).
 
-```
-$ yarn link "@guardian/braze-components"
-```
-
-To revert back to using the published version of the package:
+#### Build @guardian/braze-components locally
 
 ```
-$ yarn unlink "@guardian/braze-components"
-$ yarn install --force
+$ yarn build
 ```
 
-[`yarn link`]: https://classic.yarnpkg.com/en/docs/cli/link/
+#### Publish your local @guardian/braze-components to the local yalc registry
 
-NOTE:
+In your local checkout of `@guardian/braze-components`, at the root:
 
--   Ensure you build this library before adding it locally to your project,
-    by running `yarn build`. You can also use `yarn watch` to build automatically
-    when the source code is changed.
+```
+$ yalc publish
+```
 
--   The external project (e.g. DCR/frontend) may not be set up to watch changes from linked modules. Removing: `ignored: /node_modules/,` from [`watchOptions`](https://github.com/guardian/frontend/blob/main/dev/watch.js#L30) in frontend will enable `make watch` (in frontend) to also track changes to `braze-components`.
+#### Use the version of braze-components from the local yalc registry
+
+```
+$ yalc add @guardian/braze-components
+```
+
+For example, for DCR this should be run from within the dotcom-rendering
+sub-project.
+
+This will update the local package.json with a yalc ref. This is expected, but
+the change shouldn't be committed.
+
+#### Notes
+
+The steps above should be repeated when you make a change to braze-components
+and you want to see it locally. Don't forget to re run `yarn build`!
 
 ## Publishing to NPM
 


### PR DESCRIPTION
## What does this change?

Updates the README to use [`yalc`](https://github.com/wclr/yalc) for integrating local/unpublished braze-components with a consuming project, e.g. DCR.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
