### PR TITLE
Add reminder button to styleable banner

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -9,7 +9,7 @@ import { replaceNonArticleCountPlaceholders } from './placeholders';
 import { TrackClick } from '../utils/tracking';
 import { FetchEmail } from '../types/dcrTypes';
 import { ReminderStage } from '../logic/reminders';
-import { ReminderButtonColorStyles } from '../styles/colorData';
+import { ReminderButtonColorStyles, ContributionButtonColorStyles } from '../styles/colorData';
 import { HeaderSection } from './HeaderSection';
 
 // Custom styles for <a> tags in the Epic content
@@ -65,11 +65,17 @@ const styles = {
     `,
 };
 
-const defaultColors: ReminderButtonColorStyles = {
+const defaultReminderColors: ReminderButtonColorStyles = {
     styleReminderButton: '#121212',
     styleReminderButtonBackground: '#ededed',
     styleReminderButtonHover: '#dcdcdc',
     styleReminderAnimation: '#707070',
+};
+
+const defaultContributeColors: ContributionButtonColorStyles = {
+    styleButton: '#ffffff',
+    styleButtonBackground: '#052962',
+    styleButtonHover: '#234b8a',
 };
 
 export type BrazeMessageProps = {
@@ -173,8 +179,9 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                         <ContributionCtaButton
                             buttonText={buttonText as string}
                             buttonUrl={buttonUrl as string}
-                            hidePaymentIcons={hidePaymentIcons as string}
+                            showPaymentIcons={hidePaymentIcons !== 'true'}
                             ophanComponentId={ophanComponentId as string}
+                            userStyles={defaultContributeColors}
                             trackClick={trackClick}
                         />
                         {reminderStage && (
@@ -185,7 +192,7 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                                 ophanComponentId={ophanComponentId as string}
                                 trackClick={trackClick}
                                 fetchEmail={fetchEmail}
-                                userStyles={defaultColors}
+                                userStyles={defaultReminderColors}
                             />
                         )}
                     </div>

--- a/src/StyleableBannerWithLink/index.stories.tsx
+++ b/src/StyleableBannerWithLink/index.stories.tsx
@@ -87,6 +87,36 @@ export default {
             type: { name: 'string', required: false },
             description: 'CTA button background hover color - defaults to "#234b8a"',
         },
+        reminderStage: {
+            name: 'reminderStage',
+            type: { name: 'string', required: false },
+            description: 'The type of stage (PRE, POST, WINBACK)',
+        },
+        reminderOption: {
+            name: 'reminderOption',
+            type: { name: 'string', required: false },
+            description: 'Extra data to be associated with a reminder sign-up',
+        },
+        styleReminderButton: {
+            name: 'styleReminderButton',
+            type: { name: 'string', required: false },
+            description: 'Reminder button text color - defaults to "#121212"',
+        },
+        styleReminderButtonBackground: {
+            name: 'styleReminderButtonBackground',
+            type: { name: 'string', required: false },
+            description: 'Reminder button background color - defaults to "#ededed"',
+        },
+        styleReminderButtonHover: {
+            name: 'styleReminderButtonHover',
+            type: { name: 'string', required: false },
+            description: 'Reminder button background hover color - defaults to "#dcdcdc"',
+        },
+        styleReminderAnimation: {
+            name: 'styleReminderAnimation',
+            type: { name: 'string', required: false },
+            description: 'Reminder button animated dots color - defaults to "#707070"',
+        },
         imageUrl: {
             name: 'imageUrl (use Grid image picker)',
             type: { name: 'string', required: true },
@@ -149,6 +179,12 @@ const StoryTemplate = (args: BrazeMessageProps & { componentName: string }): Rea
         styleCloseBackground: args.styleCloseBackground,
         styleCloseHover: args.styleCloseHover,
         ophanComponentId: args.ophanComponentId,
+        reminderStage: args.reminderStage,
+        reminderOption: args.reminderOption,
+        styleReminderButton: args.styleReminderButton,
+        styleReminderButtonBackground: args.styleReminderButtonBackground,
+        styleReminderButtonHover: args.styleReminderButtonHover,
+        styleReminderAnimation: args.styleReminderAnimation,
     };
 
     // This is to make the data available to the guPreview add-on:
@@ -191,6 +227,12 @@ DefaultStory.args = {
     styleButton: '#ffffff',
     styleButtonBackground: '#052962',
     styleButtonHover: '#234b8a',
+    reminderStage: 'PRE',
+    reminderOption: 'recurring-contribution-upsell',
+    styleReminderButton: '#121212',
+    styleReminderButtonBackground: '#ededed',
+    styleReminderButtonHover: '#dcdcdc',
+    styleReminderAnimation: '#707070',
     imageAltText: 'Accessible image description',
     imagePosition: 'bottom',
     styleClose: '#052962',

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react';
-import { Button, LinkButton, SvgCross } from '@guardian/source-react-components';
+import { Button, SvgCross } from '@guardian/source-react-components';
 import { useEscapeShortcut, OnCloseClick, CLOSE_BUTTON_ID } from '../bannerCommon/bannerActions';
+import { ContributionCtaButton } from '../components/ContributionCtaButton';
+import { ReminderCtaButton } from '../components/ReminderCtaButton';
+import { ReminderStage } from '../logic/reminders';
 import type { TrackClick } from '../utils/tracking';
+import { FetchEmail } from '../types/dcrTypes';
 import { StyleableBannerColorStyles } from '../styles/colorData';
 import { selfServeStyles } from '../styles/bannerCommon';
 import { canRender, COMPONENT_NAME } from './canRender';
-import { PaymentIcons } from '../components/PaymentIcons';
+import { ColorValueHex } from '../logic/types';
 export { COMPONENT_NAME };
 
 export type BrazeMessageProps = {
@@ -16,6 +20,8 @@ export type BrazeMessageProps = {
     buttonText?: string;
     buttonUrl?: string;
     showPaymentIcons?: string;
+    reminderStage?: ReminderStage;
+    reminderOption?: string;
     includeReminderCta?: string;
     imageUrl?: string;
     imageAltText?: string;
@@ -58,6 +64,7 @@ const defaultColors: StyleableBannerColorStyles = {
 export type Props = {
     brazeMessageProps: BrazeMessageProps;
     trackClick: TrackClick;
+    fetchEmail: FetchEmail;
 };
 
 const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
@@ -74,14 +81,32 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
             buttonText,
             buttonUrl,
             showPaymentIcons = 'false',
+            reminderStage,
+            reminderOption,
             imageUrl,
             imageAltText = '',
             imagePosition = 'center',
         },
         trackClick,
+        fetchEmail,
     } = props;
 
-    const styles = selfServeStyles(props.brazeMessageProps, defaultColors);
+    const brazeProps = props.brazeMessageProps;
+
+    const styles = selfServeStyles(brazeProps, defaultColors);
+
+    const reminderStyles = {
+        styleReminderButton: brazeProps?.styleReminderButton as ColorValueHex,
+        styleReminderButtonBackground: brazeProps?.styleReminderButtonBackground as ColorValueHex,
+        styleReminderButtonHover: brazeProps?.styleReminderButtonHover as ColorValueHex,
+        styleReminderAnimation: brazeProps?.styleReminderAnimation as ColorValueHex,
+    };
+
+    const contributeStyles = {
+        styleButton: brazeProps?.styleButton as ColorValueHex,
+        styleButtonBackground: brazeProps?.styleButtonBackground as ColorValueHex,
+        styleButtonHover: brazeProps?.styleButtonHover as ColorValueHex,
+    };
 
     const [showBanner, setShowBanner] = useState(true);
 
@@ -117,20 +142,28 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
                             <strong css={styles.highlight}>{highlight}</strong>
                         </p>
                     ) : null}
+
                     <div css={styles.primaryButtonWrapper}>
-                        <LinkButton
-                            href={buttonUrl}
-                            css={styles.primaryButton}
-                            onClick={() =>
-                                trackClick({
-                                    internalButtonId: 0,
-                                    ophanComponentId: ophanComponentId as string,
-                                })
-                            }
-                        >
-                            {buttonText}
-                        </LinkButton>
-                        {showPaymentIcons === 'true' && <PaymentIcons />}
+                        <ContributionCtaButton
+                            buttonText={buttonText as string}
+                            buttonUrl={buttonUrl as string}
+                            showPaymentIcons={showPaymentIcons === 'true'}
+                            ophanComponentId={ophanComponentId as string}
+                            userStyles={contributeStyles}
+                            trackClick={trackClick}
+                        />
+                        {reminderStage && (
+                            <ReminderCtaButton
+                                reminderComponent="BANNER"
+                                reminderStage={reminderStage}
+                                reminderOption={reminderOption}
+                                ophanComponentId={ophanComponentId as string}
+                                trackClick={trackClick}
+                                fetchEmail={fetchEmail}
+                                userStyles={reminderStyles}
+                                isBanner={true}
+                            />
+                        )}
                     </div>
                 </div>
                 <div

--- a/src/components/ContributionCtaButton.tsx
+++ b/src/components/ContributionCtaButton.tsx
@@ -5,50 +5,76 @@ import { LinkButton } from '@guardian/source-react-components';
 
 import { PaymentIcons } from './PaymentIcons';
 import { TrackClick } from '../utils/tracking';
-import { contributionsTheme } from '../styles/colorData';
+import { contributionsTheme, getColors, ContributionButtonColorStyles } from '../styles/colorData';
 
-const buttonWrapperStyles = css`
-    margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    align-items: flex-start;
-`;
+const defaultButtonColors: ContributionButtonColorStyles = {
+    styleButton: '#ffffff',
+    styleButtonBackground: '#052962',
+    styleButtonHover: '#234b8a',
+};
 
-const buttonMargins = css`
-    margin: ${space[1]}px ${space[2]}px ${space[1]}px 0;
-`;
+const getButtonStyles = (
+    userVals: Partial<ContributionButtonColorStyles>,
+    defaults: ContributionButtonColorStyles,
+) => {
+    const styles = getColors(userVals, defaults);
+    return {
+        buttonWrapperStyles: css`
+            margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            align-items: flex-start;
+            max-width: 50%;
+        `,
+        buttonMargins: css`
+            margin: ${space[1]}px ${space[2]}px ${space[1]}px 0;
+        `,
+        contributionButtonOverrides: css`
+            background-color: ${styles.styleButtonBackground} !important;
+            color: ${styles.styleButton} !important;
+
+            :hover {
+                background-color: ${styles.styleButtonHover} !important;
+            }
+        `,
+    };
+};
 
 interface ContributionCtaButtonProps {
     buttonText: string;
     buttonUrl: string;
-    hidePaymentIcons: string;
+    showPaymentIcons: boolean;
     ophanComponentId: string;
     trackClick: TrackClick;
+    userStyles: Partial<ContributionButtonColorStyles>;
 }
 
 export const ContributionCtaButton = ({
     buttonUrl,
     buttonText,
-    hidePaymentIcons,
+    showPaymentIcons,
     ophanComponentId,
     trackClick,
+    userStyles = {},
 }: ContributionCtaButtonProps) => {
-    const showPaymentIcons = hidePaymentIcons !== 'true';
     const internalButtonId = 0;
+
+    const styles = getButtonStyles(userStyles, defaultButtonColors);
 
     const onClick = () => trackClick({ internalButtonId, ophanComponentId });
 
     return (
-        <div css={buttonWrapperStyles}>
-            <div css={buttonMargins}>
+        <div css={styles.buttonWrapperStyles}>
+            <div css={styles.buttonMargins}>
                 <ThemeProvider theme={contributionsTheme}>
                     <LinkButton
                         href={buttonUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         priority={'primary'}
+                        css={styles.contributionButtonOverrides}
                         onClick={onClick}
                     >
                         {buttonText}

--- a/src/components/ReminderCtaButton.tsx
+++ b/src/components/ReminderCtaButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css, SerializedStyles, ThemeProvider } from '@emotion/react';
 import { body, space } from '@guardian/source-foundations';
-import { Button } from '@guardian/source-react-components';
+import { LinkButton } from '@guardian/source-react-components';
 
 import {
     buildReminderFields,
@@ -46,7 +46,7 @@ const getButtonStyles = (
             margin-top: ${space[3]}px;
         `,
         remindMeButtonOverrides: css`
-            background-color: {styles.styleReminderButtonBackground} !important;
+            background-color: ${styles.styleReminderButtonBackground} !important;
             color: ${styles.styleReminderButton} !important;
 
             :hover {
@@ -62,22 +62,20 @@ const getButtonStyles = (
 
 interface RemindMeButtonProps {
     buttonStyles: Record<string, SerializedStyles>;
-    disabled: boolean;
     ctaText: string;
     onClick: () => void;
 }
 
-const RemindMeButton = ({ buttonStyles, disabled, ctaText, onClick }: RemindMeButtonProps) => (
+const RemindMeButton = ({ buttonStyles, ctaText, onClick }: RemindMeButtonProps) => (
     <div css={buttonStyles.buttonMargins}>
         <ThemeProvider theme={contributionsTheme}>
-            <Button
-                disabled={disabled}
+            <LinkButton
                 onClick={() => onClick()}
                 priority="tertiary"
                 css={buttonStyles.remindMeButtonOverrides}
             >
                 {ctaText}
-            </Button>
+            </LinkButton>
         </ThemeProvider>
     </div>
 );
@@ -90,6 +88,7 @@ interface ReminderCtaButtonProps {
     trackClick: TrackClick;
     fetchEmail: FetchEmail;
     userStyles: Partial<ReminderButtonColorStyles>;
+    isBanner?: boolean;
 }
 
 export const ReminderCtaButton = ({
@@ -100,6 +99,7 @@ export const ReminderCtaButton = ({
     trackClick,
     fetchEmail,
     userStyles = {},
+    isBanner,
 }: ReminderCtaButtonProps): JSX.Element => {
     const { reminderCta, reminderPeriod, reminderLabel } = buildReminderFields();
     const [remindState, setRemindState] = useState<InteractiveButtonStatus>('DEFAULT');
@@ -134,28 +134,20 @@ export const ReminderCtaButton = ({
         case 'DEFAULT':
             return (
                 <div css={styles.buttonWrapperStyles}>
-                    <RemindMeButton
-                        buttonStyles={styles}
-                        onClick={onClick}
-                        disabled={false}
-                        ctaText={reminderCta}
-                    />
-                    <div css={styles.smallPrint}>
-                        We will send you a maximum of two emails in {reminderLabel}. To find out
-                        what personal data we collect and how we use it, view our{' '}
-                        <a href="https://manage.theguardian.com/email-prefs">Privacy Policy</a>.
-                    </div>
+                    <RemindMeButton buttonStyles={styles} onClick={onClick} ctaText={reminderCta} />
+                    {!isBanner && (
+                        <div css={styles.smallPrint}>
+                            We will send you a maximum of two emails in {reminderLabel}. To find out
+                            what personal data we collect and how we use it, view our{' '}
+                            <a href="https://manage.theguardian.com/email-prefs">Privacy Policy</a>.
+                        </div>
+                    )}
                 </div>
             );
         case 'FAILURE':
             return (
                 <div css={styles.buttonWrapperStyles}>
-                    <RemindMeButton
-                        buttonStyles={styles}
-                        onClick={onClick}
-                        disabled={false}
-                        ctaText={reminderCta}
-                    />
+                    <RemindMeButton buttonStyles={styles} onClick={onClick} ctaText={reminderCta} />
                     <div css={styles.smallPrint}>
                         There was an error creating the reminder. Please try again.
                     </div>

--- a/src/styles/bannerCommon.ts
+++ b/src/styles/bannerCommon.ts
@@ -179,11 +179,8 @@ export const selfServeStyles = (userVals: Record<string, string>, defaults: Bann
             margin: ${space[4]}px ${space[2]}px ${space[1]}px 0;
             display: flex;
             flex-wrap: wrap;
-            align-items: center;
-
-            &.hidden {
-                display: none;
-            }
+            justify-content: flex-start;
+            align-items: flex-start;
         `,
 
         primaryButton: css`

--- a/src/styles/colorData.ts
+++ b/src/styles/colorData.ts
@@ -21,27 +21,35 @@ export interface LoadingDotsColorStyles {
     styleReminderAnimation: ColorValueHex;
 }
 
+export interface ContributionButtonColorStyles {
+    styleButton: ColorValueHex;
+    styleButtonBackground: ColorValueHex;
+    styleButtonHover: ColorValueHex;
+}
+
 export interface ReminderButtonColorStyles extends LoadingDotsColorStyles {
     styleReminderButton: ColorValueHex;
     styleReminderButtonBackground: ColorValueHex;
     styleReminderButtonHover: ColorValueHex;
 }
 
-export interface BannerColorStyles {
+export interface BannerCopyColorStyles {
     styleBackground: ColorValueHex;
     styleHeader: ColorValueHex;
     styleBody: ColorValueHex;
     styleHighlight: ColorValueHex;
     styleHighlightBackground: ColorValueHex;
-    styleButton: ColorValueHex;
-    styleButtonBackground: ColorValueHex;
-    styleButtonHover: ColorValueHex;
     styleClose: ColorValueHex;
     styleCloseBackground: ColorValueHex;
     styleCloseHover: ColorValueHex;
 }
 
-export interface StyleableBannerColorStyles extends ReminderButtonColorStyles, BannerColorStyles {}
+export interface BannerColorStyles extends BannerCopyColorStyles, ContributionButtonColorStyles {}
+
+export interface StyleableBannerColorStyles
+    extends ReminderButtonColorStyles,
+        ContributionButtonColorStyles,
+        BannerCopyColorStyles {}
 
 // This will become an interface once we build a more generic newsletter epic with limited styling around the newsletter 1-click signup button
 export type EpicColorStyles = ReminderButtonColorStyles;
@@ -49,6 +57,7 @@ export type EpicColorStyles = ReminderButtonColorStyles;
 interface AllAvailableColorStyles
     extends LoadingDotsColorStyles,
         ReminderButtonColorStyles,
+        ContributionButtonColorStyles,
         BannerColorStyles,
         EpicColorStyles {}
 


### PR DESCRIPTION
## What does this change?
Adds the reminder button (as used in the Epic) to the styleable banner template

## How to test
Test in Storybook, and in CODE

This PR should only change the chromatic test for the Styleable banner

## Images
TODO
