### PR TITLE
Publish to NPM from CI

### DIFF
--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -79,7 +79,7 @@ jobs:
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           yarn upload-artifact
 
-release:
+  release:
     name: Release
     needs: [build]
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -78,3 +78,38 @@ jobs:
           export LAST_TEAMCITY_BUILD=1000
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
           yarn upload-artifact
+
+release:
+    name: Release
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # in order to write labels to main branch?
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Release
+        uses: changesets/action@v1
+        with:
+          publish: yarn changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -81,7 +81,7 @@ jobs:
 
   release:
     name: Release
-    needs: [build]
+    needs: [tests]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What does this change?

This adds a new step to the main GHA workflow to run `yarn changeset publish`.

When a PR is merged which is part of a changeset, a new PR will be automatically opened to create the new release. When this PR is merged to main, the new release will be published to NPM. If the release PR is not merged and subsequent PRs are merged with a changeset specified, the release PR will be updated.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
