### PR TITLE
Avoid casting user provided styles for `PrimaryCtaButton`

### DIFF
--- a/src/Epic/index.tsx
+++ b/src/Epic/index.tsx
@@ -185,7 +185,7 @@ export const Epic: React.FC<EpicProps> = (props: EpicProps) => {
                             buttonUrl={buttonUrl as string}
                             showPaymentIcons={hidePaymentIcons !== 'true'}
                             ophanComponentId={ophanComponentId as string}
-                            userStyles={defaultPrimaryCtaColors}
+                            colors={defaultPrimaryCtaColors}
                             trackClick={trackClick}
                         />
                         {reminderStage && (

--- a/src/StyleableBannerWithLink/index.tsx
+++ b/src/StyleableBannerWithLink/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, SvgCross } from '@guardian/source-react-components';
 import { useEscapeShortcut, OnCloseClick, CLOSE_BUTTON_ID } from '../bannerCommon/bannerActions';
-import { PrimaryCtaButton } from '../components/PrimaryCtaButton';
+import { PrimaryCtaButton, defaultButtonColors } from '../components/PrimaryCtaButton';
 import { ReminderCtaButton } from '../components/ReminderCtaButton';
 import { ReminderStage } from '../logic/reminders';
 import type { TrackClick } from '../utils/tracking';
@@ -9,6 +9,7 @@ import { FetchEmail } from '../types/dcrTypes';
 import { StyleableBannerColorStyles } from '../styles/colorData';
 import { selfServeStyles } from '../styles/bannerCommon';
 import { canRender, COMPONENT_NAME } from './canRender';
+import { getColors } from '../styles/colorData';
 import { OptionalColorValueHex } from '../logic/types';
 export { COMPONENT_NAME };
 
@@ -107,11 +108,7 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
 
     const showPrivacyTextBoolean = showPrivacyText === 'true';
 
-    const primaryCtaStyles = {
-        styleButton: brazeProps?.styleButton as OptionalColorValueHex,
-        styleButtonBackground: brazeProps?.styleButtonBackground as OptionalColorValueHex,
-        styleButtonHover: brazeProps?.styleButtonHover as OptionalColorValueHex,
-    };
+    const primaryCtaStyles = getColors(brazeProps, defaultButtonColors);
 
     const [showBanner, setShowBanner] = useState(true);
 
@@ -154,7 +151,7 @@ const StyleableBannerWithLink: React.FC<Props> = (props: Props) => {
                             buttonUrl={buttonUrl as string}
                             showPaymentIcons={showPaymentIcons === 'true'}
                             ophanComponentId={ophanComponentId as string}
-                            userStyles={primaryCtaStyles}
+                            colors={primaryCtaStyles}
                             trackClick={trackClick}
                         />
                         {reminderStage && (

--- a/src/components/PrimaryCtaButton.tsx
+++ b/src/components/PrimaryCtaButton.tsx
@@ -5,19 +5,15 @@ import { LinkButton } from '@guardian/source-react-components';
 
 import { PaymentIcons } from './PaymentIcons';
 import { TrackClick } from '../utils/tracking';
-import { contributionsTheme, getColors, PrimaryButtonColorStyles } from '../styles/colorData';
+import { contributionsTheme, PrimaryButtonColorStyles } from '../styles/colorData';
 
-const defaultButtonColors: PrimaryButtonColorStyles = {
+export const defaultButtonColors: PrimaryButtonColorStyles = {
     styleButton: '#ffffff',
     styleButtonBackground: '#052962',
     styleButtonHover: '#234b8a',
 };
 
-const getButtonStyles = (
-    userVals: Partial<PrimaryButtonColorStyles>,
-    defaults: PrimaryButtonColorStyles,
-) => {
-    const styles = getColors(userVals, defaults);
+const getButtonStyles = (styles: PrimaryButtonColorStyles) => {
     return {
         buttonWrapperStyles: css`
             margin: ${space[1]}px ${space[2]}px ${space[1]}px 0;
@@ -48,7 +44,7 @@ interface PrimaryCtaButtonProps {
     showPaymentIcons: boolean;
     ophanComponentId: string;
     trackClick: TrackClick;
-    userStyles: Partial<PrimaryButtonColorStyles>;
+    colors?: PrimaryButtonColorStyles;
 }
 
 export const PrimaryCtaButton = ({
@@ -57,11 +53,11 @@ export const PrimaryCtaButton = ({
     showPaymentIcons,
     ophanComponentId,
     trackClick,
-    userStyles = {},
+    colors = defaultButtonColors,
 }: PrimaryCtaButtonProps) => {
     const internalButtonId = 0;
 
-    const styles = getButtonStyles(userStyles, defaultButtonColors);
+    const styles = getButtonStyles(colors);
 
     const onClick = () => trackClick({ internalButtonId, ophanComponentId });
 


### PR DESCRIPTION
## What does this change?

Instead of casting, acknowledge that these user provided button colours might be missing and let the type guard used by `getColors` handle this. The return value from `getColors` is guaranteed to have legit `ColorValueHex` values.

I've decoupled the `getColors` logic (combine user provided styles with defaults, in case any user provided styles are missing or invalid) and the logic to take the colours and convert them to styles.

I've focused on the PrimaryCtaButton here, but the pattern could be applied to all components which support user provided styles.

## How to test

This should be purely a refactoring and shouldn't change the Chromatic snapshots at all, compared with the based branch.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
