### PR TITLE
Update Aus newsletter epic images

### DIFF
--- a/.changeset/itchy-pants-flash.md
+++ b/.changeset/itchy-pants-flash.md
@@ -1,0 +1,5 @@
+---
+'@guardian/braze-components': patch
+---
+
+Update Aus newsletter epic images

--- a/src/AUNewsletterEpic/index.tsx
+++ b/src/AUNewsletterEpic/index.tsx
@@ -5,7 +5,7 @@ import { NewsletterSubscribeCallback } from '../types/dcrTypes';
 import type { TrackClick } from '../utils/tracking';
 
 const IMAGE_URL =
-    'https://i.guim.co.uk/img/media/9f9f9c06ed5a323b13be816d5c160728c81d1bf9/0_0_784_784/master/784.png?width=196&quality=45&auto=format&s=87f06d1d5322f1fb8e2262d202f70e99';
+    'https://i.guim.co.uk/img/media/ad66f0f437d2e919f08ab5d402e4be9891425940/0_0_2000_2000/2000.png?width=400&quality=75&s=23aad591d8878d830e7f6a5fd43a010f';
 
 const newsletterId = '4148';
 

--- a/src/EpicNewsletter_AU_AfternoonUpdate/index.tsx
+++ b/src/EpicNewsletter_AU_AfternoonUpdate/index.tsx
@@ -6,7 +6,7 @@ import type { TrackClick } from '../utils/tracking';
 
 // Image URL updated
 const IMAGE_URL =
-    'https://i.guim.co.uk/img/media/1abda073e6d4069ca058a190830a723d7b5a6f2a/0_0_200_200/200.png?width=200&quality=75&s=9ae7230c7e040a6c0b3e4248ac70c068';
+    'https://i.guim.co.uk/img/media/898c5401ab51b983dc4b2508aaaf0735e6bda0e2/0_0_2000_2000/2000.png?width=400&quality=75&s=9191ec413d946058f37caced7edd0b90';
 
 // Need a newsletterId for this newsletter
 const newsletterId = '6023';


### PR DESCRIPTION
## What does this change?
A tiny update to refresh the images used in the 2 Australian newsletter epics

## How to test
Checking in Storybook should be sufficient

## Images

![Screenshot 2023-12-04 at 14 30 21](https://github.com/guardian/braze-components/assets/5357530/04da5933-1e1e-45fb-9ab7-f5e36b5f61b3)

![Screenshot 2023-12-04 at 14 30 42](https://github.com/guardian/braze-components/assets/5357530/b609b2bb-902e-4c78-89f7-815adfd52948)
