### PR TITLE
Fix error when `createReminder` is called

### DIFF
--- a/.changeset/pink-apes-destroy.md
+++ b/.changeset/pink-apes-destroy.md
@@ -1,0 +1,5 @@
+---
+'@guardian/braze-components': minor
+---
+
+Fix createReminder function

--- a/src/logic/reminders.ts
+++ b/src/logic/reminders.ts
@@ -1,4 +1,4 @@
-import { isTest } from '../utils/env';
+import { isStorybook, isTest } from '../utils/env';
 
 export type ReminderPlatform = 'WEB' | 'AMP';
 
@@ -53,7 +53,7 @@ export const buildReminderFields = (today: Date = new Date()): ReminderFields =>
 
 export const createReminder = (signupData: OneOffSignupRequest): Promise<void> => {
     const url = 'https://support.theguardian.com/reminders/create/one-off';
-    if (process.env.STORYBOOK || isTest()) {
+    if (isStorybook() || isTest()) {
         return Promise.resolve();
     } else {
         return fetch(url, {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,7 +3,7 @@
 export const isDevelopment = (): boolean => process.env.NODE_ENV === 'development';
 export const isTest = (): boolean => process.env.NODE_ENV === 'test';
 
-// isStorybook is safe to use client side because we attempt to determins if
+// isStorybook is safe to use client side because we attempt to determine if
 // process is defined before using
 export const isStorybook = (): boolean => {
     if (typeof process === 'object') {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,2 +1,14 @@
+// isDevelopment and isTest are safe to use client side because
+// process.env.NODE_ENV is replaced by rollup
 export const isDevelopment = (): boolean => process.env.NODE_ENV === 'development';
 export const isTest = (): boolean => process.env.NODE_ENV === 'test';
+
+// isStorybook is safe to use client side because we attempt to determins if
+// process is defined before using
+export const isStorybook = (): boolean => {
+    if (typeof process === 'object') {
+        return process?.env?.STORYBOOK === 'true';
+    }
+
+    return false;
+};


### PR DESCRIPTION
## What does this change?

While attempting to test the reminders work from #433 and #422 in CODE I ran into an issue which was preventing the reminder sign-up from working. In the code we attempt to check whether we're running in Storybook, in which case we return a stub promise which immediately resolves. However, in the context of DCR `process.env` isn't available so the attempt to read `process.env.STORYBOOK` always fails and causes an error, resulting in the attempt to create the reminder failing. This change allows us to detect storybook in a way that's safe to do in DCR.

## How to test

I've tested locally running DCR and publishing braze-components with yalc. I see that the reminder signup from the banner now works:

<img width="511" alt="Screenshot 2023-12-12 at 15 59 35" src="https://github.com/guardian/braze-components/assets/379839/8a631c63-76e7-4373-a9c8-522fd1dc47a0">

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
