### PR TITLE
Add canRender to BrazeMessages constructor interface

### DIFF
--- a/.changeset/lovely-dingos-teach.md
+++ b/.changeset/lovely-dingos-teach.md
@@ -1,0 +1,5 @@
+---
+'@guardian/braze-components': major
+---
+
+The BrazeMessages constructor now expects a canRender function to be passed

--- a/logic-index.ts
+++ b/logic-index.ts
@@ -3,3 +3,4 @@ export * from './src/logic/NullBrazeMessages';
 export * from './src/logic/BrazeCards';
 export * from './src/logic/NullBrazeCards';
 export * from './src/logic/LocalMessageCache';
+export * from './src/logic/canRender';

--- a/src/logic/BrazeMessages.test.ts
+++ b/src/logic/BrazeMessages.test.ts
@@ -3,8 +3,6 @@ import { createNanoEvents, Emitter } from 'nanoevents';
 import { BrazeArticleContext, BrazeMessages } from './BrazeMessages';
 import { LocalMessageCache, hydrateMessage, MessageData } from './LocalMessageCache';
 
-import { COMPONENT_NAME as BANNER_WITH_LINK_NAME } from '../BannerWithLink/canRender';
-
 const logInAppMessageImpressionSpy = jest.fn();
 
 const message1Json = `{"message":"","messageAlignment":"CENTER","duration":5000,"slideFrom":"BOTTOM","extras":{"heading":"Tom Epic Title 1","slotName":"EndOfArticle","step":"1","componentName":"Epic","highlightedText":"This text is important %%CURRENCY_SYMBOL%%1","buttonText":"Button","buttonUrl":"https://www.example.com","paragraph1":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", "ophanComponentId": "Epic"},"triggerId":"NjAzNjhmNDFkZTNmMTAxMjE4YmE5Y2E0XyRfY2MmZGkmbXY9NjAzNjhmNDFkZTNmMTAxMjE4YmE5YzZiJnBpPXdmcyZ3PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM1OCZ3cD0xNjE0MjQxNTkyJnd2PTYwMzY4ZjQxZGUzZjEwMTIxOGJhOWM5ZA==","clickAction":"NONE","uri":null,"openTarget":"NONE","dismissType":"SWIPE","icon":null,"imageUrl":null,"imageStyle":"TOP","iconColor":4294967295,"iconBackgroundColor":4278219733,"backgroundColor":4294967295,"textColor":4281545523,"closeButtonColor":4288387995,"animateIn":true,"animateOut":true,"header":null,"headerAlignment":"CENTER","headerTextColor":4281545523,"frameColor":3224580915,"buttons":[],"cropType":"FIT_CENTER","Rd":true,"Ma":false,"Qd":false,"X":{"qb":{}},"Ub":{"qb":{}},"Lg":false,"Uf":"WEB_HTML"}`;
@@ -12,7 +10,7 @@ const message2Json = `{"message":"","messageAlignment":"CENTER","duration":5000,
 
 const bannerExtras = {
     slotName: 'Banner',
-    componentName: BANNER_WITH_LINK_NAME,
+    componentName: 'BannerWithLink',
     ophanComponentId: 'banner_ophan_component_id',
     header: 'Header',
     body: 'Body',
@@ -72,10 +70,12 @@ describe('BrazeMessages', () => {
         describe('getMessageForBanner & getMessageForEndOfArticle', () => {
             it('returns a promise which resolves with message data for the correct slot', async () => {
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
 
                 const bannerPromise = brazeMessages.getMessageForBanner();
@@ -100,10 +100,12 @@ describe('BrazeMessages', () => {
 
             it('returns a promise which resolves with message data for the correct slot when queried in different order', async () => {
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
 
                 const bannerPromise = brazeMessages.getMessageForBanner();
@@ -130,10 +132,12 @@ describe('BrazeMessages', () => {
 
             it('returns a message which is capable of logging an impression', async () => {
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
 
                 const bannerPromise = brazeMessages.getMessageForBanner();
@@ -152,10 +156,12 @@ describe('BrazeMessages', () => {
 
             it('returns a message with an id', async () => {
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
 
                 const bannerPromise = brazeMessages.getMessageForBanner();
@@ -183,10 +189,12 @@ describe('BrazeMessages', () => {
                 );
                 const freshMessage = buildMessage(JSON.parse(message2Json));
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
                 fakeAppBoy.emit(freshMessage);
 
@@ -207,10 +215,12 @@ describe('BrazeMessages', () => {
                 );
                 const freshMessage = buildMessage(JSON.parse(message2Json));
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
                 fakeAppBoy.emit(freshMessage);
 
@@ -233,10 +243,12 @@ describe('BrazeMessages', () => {
                 );
                 const freshMessage = buildMessage(JSON.parse(message2Json));
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
                 fakeAppBoy.emit(freshMessage);
 
@@ -267,10 +279,12 @@ describe('BrazeMessages', () => {
                     (e) => console.log(e),
                 );
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
                 const articleContext: BrazeArticleContext = {
                     section: 'environment',
@@ -293,10 +307,12 @@ describe('BrazeMessages', () => {
                     (e) => console.log(e),
                 );
                 const fakeAppBoy = new FakeAppBoy();
+                const canRender = () => true;
                 const brazeMessages = new BrazeMessages(
                     fakeAppBoy as unknown as typeof appboy,
                     LocalMessageCache,
                     (error, identifier) => console.log(identifier, error),
+                    canRender,
                 );
                 const articleContext: BrazeArticleContext = {
                     section: 'environment',

--- a/src/logic/canRender.ts
+++ b/src/logic/canRender.ts
@@ -1,74 +1,74 @@
-import type { Extras } from './logic/types';
+import type { Extras } from './types';
 
 // Banners
 // --------------------------------------------
 import {
     COMPONENT_NAME as APP_BANNER_NAME,
     canRender as appBannerCanRender,
-} from './AppBanner/canRender';
+} from '../AppBanner/canRender';
 
 import {
     COMPONENT_NAME as BANNER_WITH_LINK_NAME,
     canRender as bannerWithLinkCanRender,
-} from './BannerWithLink/canRender';
+} from '../BannerWithLink/canRender';
 
 import {
     COMPONENT_NAME as STYLEABLE_BANNER_WITH_LINK_NAME,
     canRender as styleableBannerWithLinkCanRender,
-} from './StyleableBannerWithLink/canRender';
+} from '../StyleableBannerWithLink/canRender';
 
 import {
     COMPONENT_NAME as BANNER_NEWSLETTER_NAME,
     canRender as bannerNewsletterCanRender,
-} from './BannerNewsletter/canRender';
+} from '../BannerNewsletter/canRender';
 
 // Default Epics
 // --------------------------------------------
-import { COMPONENT_NAME as EPIC_NAME, canRender as epicCanRender } from './Epic/canRender';
+import { COMPONENT_NAME as EPIC_NAME, canRender as epicCanRender } from '../Epic/canRender';
 
 import {
     COMPONENT_NAME as EPIC_WITH_IMAGE_NAME,
     canRender as epicWithImageCanRender,
-} from './EpicWithSpecialHeader/canRender';
+} from '../EpicWithSpecialHeader/canRender';
 
 // Old newsletter Epics
 // --------------------------------------------
 import {
     COMPONENT_NAME as US_NEWSLETTER_EPIC_NAME,
     canRender as usNewsletterEpicCanRender,
-} from './USNewsletterEpic/canRender';
+} from '../USNewsletterEpic/canRender';
 
 import {
     COMPONENT_NAME as AU_NEWSLETTER_EPIC_NAME,
     canRender as auNewsletterEpicCanRender,
-} from './AUNewsletterEpic/canRender';
+} from '../AUNewsletterEpic/canRender';
 
 import {
     COMPONENT_NAME as UK_NEWSLETTER_EPIC_NAME,
     canRender as ukNewsletterEpicCanRender,
-} from './UKNewsletterEpic/canRender';
+} from '../UKNewsletterEpic/canRender';
 
 import {
     COMPONENT_NAME as DTE_NEWSLETTER_EPIC_NAME,
     canRender as dteNewsletterEpicCanRender,
-} from './DownToEarthNewsletterEpic/canRender';
+} from '../DownToEarthNewsletterEpic/canRender';
 
 // 2023 newsletter Epics
 // --------------------------------------------
 import {
     COMPONENT_NAME as EPICNEWSLETTER_AU_AFTERNOONUPDATE,
     canRender as EpicNewsletter_AU_AfternoonUpdate_canRender,
-} from './EpicNewsletter_AU_AfternoonUpdate/canRender';
+} from '../EpicNewsletter_AU_AfternoonUpdate/canRender';
 
 import {
     COMPONENT_NAME as EPICNEWSLETTER_THEGUIDE,
     canRender as EpicNewsletter_TheGuide_canRender,
-} from './EpicNewsletter_TheGuide/canRender';
+} from '../EpicNewsletter_TheGuide/canRender';
 
 import {
     COMPONENT_NAME as NEWSLETTEREPIC_NAME,
     canRender as NewsletterEpic_canRender,
-} from './NewsletterEpic/canRender';
+} from '../NewsletterEpic/canRender';
 
 // Types, functionality, exports
 // --------------------------------------------


### PR DESCRIPTION
## What does this change?

The `canRender` function is now passed to the `BrazeMessages` constructor instead of importing directly. This is to facilitate pulling components (which will be co-located with their individual `canRender`) gradually over to DCR. Instead of `BrazeMessages` being able to access `canRender` directly, it will be provided by the caller. For the first pass we'll be passing back in the exact function we currently reference directly. But as components are migrated to DCR we'll have to layer in their own can render behaviour.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
