### PR TITLE
Broaden @guardian/source peer dep requirements up to v6

### DIFF
--- a/.changeset/healthy-elephants-own.md
+++ b/.changeset/healthy-elephants-own.md
@@ -1,0 +1,5 @@
+---
+'@guardian/braze-components': minor
+---
+
+Broader @guardian/source peer dependency range

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
     "@guardian/libs": "^16.0.0",
-    "@guardian/source": "^6.0.0",
+    "@guardian/source": ">= 1.0.1 < 7",
     "react": "17.0.2 || 18.2.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@guardian/grid-client": "^1.1.1",
     "@guardian/libs": "^16.0.0",
     "@guardian/node-riffraff-artifact": "^0.3.2",
-    "@guardian/source": "^1.0.1",
+    "@guardian/source": "^6.0.0",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",
@@ -96,7 +96,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
     "@guardian/libs": "^16.0.0",
-    "@guardian/source": "^1.0.1",
+    "@guardian/source": "^6.0.0",
     "react": "17.0.2 || 18.2.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3045,10 +3045,10 @@
     yaml "^1.7.2"
     yargs "^15.4.1"
 
-"@guardian/source@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/source/-/source-1.0.1.tgz#27e3ee2d44a1fbbd7c24705cccdbf643e3958ba4"
-  integrity sha512-LzOwkpDuKbOmVv7aOldEJhqaaKdNRP3EpWOAlJVfK08jDTwWtdM5CYTOn/8blJHLTUnEAcxZ6dH+S5zalGhFgg==
+"@guardian/source@^6.0.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source/-/source-6.1.0.tgz#9c4e289a4529002e4f3252577a28c237457e52ae"
+  integrity sha512-Vez2zPyOa6SLNUSQ6XOIwFPGOcgRrg9MgRQTvG9ERUsYamuDFC3WiGi5U3tMll23WEekKSshd8jDZsAyWz5u5w==
   dependencies:
     mini-svg-data-uri "1.4.4"
 


### PR DESCRIPTION
## What does this change?

Broaden the `@guardian/source` peer dep range from `^1.0.1` to `>= 1.0.1 < 7`. I've tested with v6 and the component rendering looks good (I've made an assumption that things are fine in the intermediate major versions too).

As per our recommendations I've bumped the dev version to the latest acceptable.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Check that Chromatic is happy.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
