### PR TITLE
Add security policy property to CloudFront

### DIFF
--- a/cdk/lib/__snapshots__/braze-components.test.ts.snap
+++ b/cdk/lib/__snapshots__/braze-components.test.ts.snap
@@ -78,6 +78,7 @@ Object {
                 ],
               ],
             },
+            "MinimumProtocolVersion": "TLSv1.2_2018",
             "SslSupportMethod": "sni-only",
           },
         },

--- a/cdk/lib/braze-components.ts
+++ b/cdk/lib/braze-components.ts
@@ -7,6 +7,7 @@ import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
     CloudFrontWebDistribution,
     OriginAccessIdentity,
+    SecurityPolicyProtocol,
     ViewerCertificate,
 } from 'aws-cdk-lib/aws-cloudfront';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
@@ -52,6 +53,7 @@ export class BrazeComponents extends GuStack {
             ],
             viewerCertificate: ViewerCertificate.fromAcmCertificate(certificate, {
                 aliases: [props.domainName],
+                securityPolicy: SecurityPolicyProtocol.TLS_V1_2_2018,
             }),
         });
 


### PR DESCRIPTION
## What does this change?

This adds the `securityPolicy` property to CloudFront for the hosted storybook, and sets it to the highest options `TLS_V1_2_2018`. This will stop it from allowing insecure TLS ciphers.

## How to test

Tested in CODE and PROD (as Grid integration doesn't work in CODE)
