### PR TITLE
Update to Source 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@guardian/grid-client": "^1.1.1",
     "@guardian/libs": "^16.0.0",
     "@guardian/node-riffraff-artifact": "^0.3.2",
-    "@guardian/source": "^8.0.0",
+    "@guardian/source": "^9.0.0",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-babel": "^5.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",
@@ -97,7 +97,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
     "@guardian/libs": "^16.0.0",
-    "@guardian/source": "^8.0.0",
+    "@guardian/source": "^9.0.0",
     "react": "17.0.2 || 18.2.0"
   },
   "publishConfig": {

--- a/src/components/NewsletterFrequencyBlock.tsx
+++ b/src/components/NewsletterFrequencyBlock.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { SvgClock } from '@guardian/source/react-components';
+import { SvgClockFilled } from '@guardian/source/react-components';
 import { textSans17 } from '@guardian/source/foundations';
 
 import type { NewsletterFrequencyColorStyles } from '../styles/colorData';
@@ -24,7 +24,7 @@ export const NewsletterFrequencyBlock: React.FC<NewsletterFrequencyBlockProps> =
     return (
         <div css={styles.container}>
             <span css={styles.clock}>
-                <SvgClock />
+                <SvgClockFilled />
             </span>
             <span css={styles.text}>{frequency}</span>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,10 +2207,10 @@
     yaml "^1.7.2"
     yargs "^15.4.1"
 
-"@guardian/source@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source/-/source-8.0.0.tgz#99468fc96d8cb27669aaaa3355fa18a201208b1e"
-  integrity sha512-P6OTmCWsSWkT20M5uRAPoKonsz3nikOj308mUEiFDO2vpx1oyG2V6KP0YBlDxoSzw7EW6KbM9Ptat6VNd55cEw==
+"@guardian/source@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source/-/source-9.0.0.tgz#e8b9ba1d7796fda62a5e7a3904c36cf80de2bc41"
+  integrity sha512-RQuLqVp11x9hKtAKrOOvxWAtnUzNKDL4Uzk6rWGxfx9GDh4gc9+O+45NUXFM1DAzQkvyDXr3vNl5/iVrEJ+cPw==
   dependencies:
     mini-svg-data-uri "1.4.4"
 


### PR DESCRIPTION
## What does this change?

- Updates to latest release of Source
- Updates `SvgClock` import which has been renamed as part of the icon library update
 
DCR have a pending [PR that updates Source](https://github.com/guardian/dotcom-rendering/pull/13648), but requires a corresponding update to `braze-components` due to the breaking change.
