### PR TITLE
Fixed @braze/web-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-env": "^7.22.6",
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
-    "@braze/web-sdk": "^5.8.1",
+    "@braze/web-sdk": "5.8.1",
     "@changesets/cli": "^2.27.10",
     "@emotion/babel-preset-css-prop": "^11.1.2",
     "@emotion/eslint-plugin": "^11.10.0",


### PR DESCRIPTION
## What does this change?
This PR modifies the version specification for the @braze/web-sdk package in package.json by changing from a caret version range (^5.8.1) to an exact version (5.8.1). While this doesn't change the actual version being used, it enforces that this specific version will be installed rather than allowing compatible updates within the same major version.

## How to test

1. Delete your node_modules directory and package-lock.json
2. Run npm install to verify the exact version 5.8.1 is installed
3. Run your application's test suite to ensure all Braze SDK functionality continues to work as expected
4. Verify that no unexpected console warnings or errors appear related to the Braze SDK

## How can we measure success?

- Build passes without errors
- No regressions in Braze SDK functionality
- Consistent dependency installation across environments (dev, CI, production)
- Reduced risk of unexpected behavior from future minor version updates

## Have we considered potential risks?

- This change eliminates automatic minor version updates, which means we'll miss bug fixes and non-breaking improvements unless we manually update
- We'll need to be more diligent about staying current with Braze SDK updates
- If other dependencies require a different version of the Braze SDK, this could potentially cause conflicts

## Images
No visual changes are expected as this is a package configuration update only.

## Accessibility
No impact on accessibility as this change only affects package version management.