### PR TITLE
Update @braze/web-sdk Package Configuration in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,7 +1655,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@braze/web-sdk@^5.8.1":
+"@braze/web-sdk@5.8.1":
   version "5.8.1"
   resolved "https://registry.yarnpkg.com/@braze/web-sdk/-/web-sdk-5.8.1.tgz#211594d647fbf3aab32ec3347546bb71f0ee6800"
   integrity sha512-J7op9y15tGwAKBXYT2rVryV59+YvRekWHk3lq1Z+oqsNa+BdrboiHTa3r7eBPww8TVcRtWDoreG2Sb3ELAb37w==


### PR DESCRIPTION
## What does this change?
This PR updates the version specification for the `@braze/web-sdk` package in the yarn.lock file, changing from a caret version range (`^5.8.1`) to an exact version (`5.8.1`). This change ensures that yarn will lock to precisely version 5.8.1 rather than potentially accepting minor version updates within the 5.x range.

## How to test
1. Delete your node_modules directory
2. Run `yarn install` to verify the exact version 5.8.1 is installed
3. Check the installed version with `yarn list @braze/web-sdk` to confirm version 5.8.1
4. Run your application's test suite to ensure all Braze SDK functionality works as expected
5. Verify no unexpected warnings or errors appear in the console related to the Braze SDK

## How can we measure success?
- Successful yarn installation without conflicts
- Consistent dependency versioning across all environments (dev, CI, production)
- No regressions in Braze SDK functionality
- More predictable builds due to exact version pinning
- Reduced risk of unexpected behavior from automatic minor version updates

## Have we considered potential risks?
- We will miss bug fixes and non-breaking improvements unless we manually update
- We'll need to establish a process to regularly check for and evaluate Braze SDK updates
- If other dependencies require a different version of the Braze SDK, this could potentially cause conflicts
- Yarn resolution might be affected if other packages depend on different versions of this SDK

## Images
No visual changes are expected as this is a dependency lock file update only.

## Accessibility
No impact on accessibility as this change only affects package version management in the lock file.