### PR TITLE
Block public access to storybook S3 bucket

### DIFF
--- a/cloudformation-static-s3.yaml
+++ b/cloudformation-static-s3.yaml
@@ -33,6 +33,11 @@ Resources:
         Type: AWS::S3::Bucket
         Properties:
             BucketName: braze-components-storybook
+            PublicAccessBlockConfiguration:
+                BlockPublicAcls: true
+                IgnorePublicAcls: true
+                BlockPublicPolicy: true
+                RestrictPublicBuckets: true
             Tags:
                 - Key: App
                   Value: !Ref App


### PR DESCRIPTION
## What does this change?

This updates the cloudformation file for the Storybook S3 bucket so that the bucket blocks all public access. There is a global setting on the AWS account already blocking public access, but the fact the bucket itself isn't specifically blocking public access is reported as a vulnerability.
There is CloudFront in front of the bucket so the bucket doesn't need to allow public access.

## How to test

- [x] Deploy braze-components-storybook
- [x] Check that bucket now blocks public access
- [x] Check that storybook can be accessed in CODE
- [x] Check that storybook can be accessed in PROD

## How can we measure success?

Once this goes out it should remediate one of the reported FSBP vulnerabilities.

## Images

| Before | After |
| --- | --- |
|  <img width="804" alt="image" src="https://github.com/user-attachments/assets/7e7ea17d-81a5-4ec1-8129-24d6c231eebd" /> | ![image](https://github.com/user-attachments/assets/044a4ba3-4bd5-4124-9cf8-3ec132d91564) |

## Note about deployment

The cloudformation is not part of CI/CD and is deployed manually. We may want to change that in future.
