### PR TITLE
Fix NPM publishing

### DIFF
--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -115,5 +115,6 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: yarn changeset publish
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React components to render messages from Braze",
   "repository": {
     "type": "git",
-    "url": "https://github.com/guardian/braze-components"
+    "url": "git+https://github.com/guardian/braze-components.git"
   },
   "author": "The Guardian",
   "license": "MIT",


### PR DESCRIPTION
## What does this change?

Publishing of this package doesn't work anymore since moving to NPM's trusted publishing.
Previous attempts to fix haven't solved the issue https://github.com/guardian/braze-components/pull/532 https://github.com/guardian/braze-components/pull/533 https://github.com/guardian/braze-components/pull/534 https://github.com/guardian/braze-components/pull/535 https://github.com/guardian/braze-components/pull/537

This PR changes the changeset publishing task so that it does not set up the git user, and also reverts the change the format of the repository url in package.json to the canonical form.
I won't know whether this fixes it until it is merged

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213293769335319