### PR TITLE
Fix pnpm install command in braze-components workflow

### DIFF
--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -125,7 +125,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: pnpm --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
Fix broken command at the pipeline:

https://github.com/guardian/braze-components/actions/runs/27409806517/job/81011751361

<img width="1266" height="272" alt="image" src="https://github.com/user-attachments/assets/a54ffb51-75e5-46ef-a11d-be44763273f7" />
