### PR TITLE
Re-enable git user setup in changeset publish action

### DIFF
--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -134,6 +134,6 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm changeset publish
-          setupGitUser: false
+          setupGitUser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix the error below:

https://github.com/guardian/braze-components/actions/runs/27411852147/job/81014912484

<img width="1610" height="726" alt="image" src="https://github.com/user-attachments/assets/577bd111-8bc9-4a49-a9e4-eaea6212ae3b" />
