### PR TITLE
Add OIDC id-token permission to changeset publish action

### DIFF
--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -137,3 +137,4 @@ jobs:
           setupGitUser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/braze-components.yml
+++ b/.github/workflows/braze-components.yml
@@ -102,6 +102,7 @@ jobs:
     permissions:
       contents: write # in order to write labels to main branch?
       pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -137,4 +138,3 @@ jobs:
           setupGitUser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Attempt to fix npm publishing

https://github.com/guardian/braze-components/actions/runs/27540562416/job/81401114065