### PR TITLE
Fix `image-alt` accessibility violation

### DIFF
--- a/.changeset/poor-keys-chew.md
+++ b/.changeset/poor-keys-chew.md
@@ -1,0 +1,5 @@
+---
+'@guardian/braze-components': patch
+---
+
+added role to image tag in NewsletterEpic to cover critical accessibility violation and updated colour palette to use non-deprecated object

--- a/src/NewsletterEpic/index.tsx
+++ b/src/NewsletterEpic/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, ThemeProvider } from '@emotion/react';
 import {
-    brand,
+    palette,
     news,
     neutral,
     space,
@@ -54,10 +54,10 @@ export const NewsletterEpic: React.FC<Props> = (props: Props) => {
     }
 
     return (
-        <ThemeProvider theme={brand}>
+        <ThemeProvider theme={palette}>
             <section css={styles.epicContainer}>
                 <div>
-                    <img css={styles.image} src={imageUrl}></img>
+                    <img role="presentation" css={styles.image} src={imageUrl}></img>
                 </div>
                 <div css={styles.rightSection}>
                     <span css={styles.heading}>{header}</span>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
It adds a presentation role to the newsletter images to avoid a critical accessibility violation that is affecting Newsletters in DCR, and changes the deprecated `brand` styles object for `palette` in the `NewsletterEpic` component

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?
Installed the storybook accessibility add-on and checked the before and after scores of the Newsletter components to see if my changes enabled the `image-alt` rule to pass

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Critical errors should no longer exist when testing in a consuming package (like DCR)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
